### PR TITLE
Fix clause separators in name fact extraction

### DIFF
--- a/examples/agent-memory-loop/README.md
+++ b/examples/agent-memory-loop/README.md
@@ -106,6 +106,9 @@ When `FACT_SAVE=1` (default), user text is scanned for:
 3. `I prefer X` -> memory content `User prefers X`
 
 Extracted memories are written as separate records with additional tags such as `fact`, `name`, and `preference`.
+Multi-clause input is split safely. Example input `my name is John, I prefer dark mode` saves:
+- `User name is John`
+- `User prefers dark mode`
 
 ## Example Interactive Transcript
 

--- a/examples/agent-memory-loop/agent_loop.py
+++ b/examples/agent-memory-loop/agent_loop.py
@@ -333,6 +333,21 @@ def _normalize_fact_value(raw: str) -> str:
     return re.sub(r"\s+", " ", raw).strip(" \t\"'`.,!?;:")
 
 
+def _normalize_name_fact_value(raw: str) -> str:
+    value = _normalize_fact_value(raw)
+    value = re.split(r"[,;:.!?]", value, maxsplit=1)[0].strip()
+    value = re.split(
+        r"\s+(?:and call me|and|but|i prefer|i like)\b",
+        value,
+        maxsplit=1,
+        flags=re.IGNORECASE,
+    )[0].strip()
+    value = _normalize_fact_value(value)
+    if len(value) > 40:
+        return ""
+    return value
+
+
 def _extract_fact_memories(user_text: str) -> list[dict]:
     text = user_text.strip()
     if not text:
@@ -370,6 +385,8 @@ def _extract_fact_memories(user_text: str) -> list[dict]:
     for pattern, template, tags in patterns:
         for match in pattern.finditer(text):
             value = _normalize_fact_value(match.group(1))
+            if "name" in tags:
+                value = _normalize_name_fact_value(value)
             if not value:
                 continue
             content = template.format(value=value)


### PR DESCRIPTION

Fixes a bug in the agent-memory-loop example where multi-clause inputs could corrupt the saved name fact
(e.g. 'my name is John, I prefer dark mode' previously saved 'User name is John, I prefer dark mode').

Adds minimal normalization for extracted name facts so long-lived memory does not get polluted.

Files changed:
- examples/agent-memory-loop/agent_loop.py
- examples/agent-memory-loop/README.md
