### PR TITLE
Docs: add branch workflow guardrails

### DIFF
--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -1,0 +1,13 @@
+# Development Workflow
+
+## Branching Rules
+
+- Do not commit directly to `main` or `master`.
+- Create a feature/bugfix branch for every change.
+- Open a pull request and merge through PR review/checks.
+
+## Recommended Branch Names
+
+- `feat/<short-topic>`
+- `bugfix/<short-topic>`
+- `chore/<short-topic>`


### PR DESCRIPTION

Adds a short dev workflow note: no direct commits to main, always use branches and PRs.
