### PR TITLE
web: fix core sessions partial-load error state

### DIFF
--- a/apps/web/app/core/sessions/page.tsx
+++ b/apps/web/app/core/sessions/page.tsx
@@ -30,6 +30,7 @@ export default function CoreSessionsPage() {
   const [loading, setLoading] = useState(true);
   const [detailLoading, setDetailLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [detailError, setDetailError] = useState<string | null>(null);
 
   useEffect(() => {
     let mounted = true;
@@ -77,10 +78,12 @@ export default function CoreSessionsPage() {
     async function loadSessionMemories() {
       if (!selectedSession) {
         setMemories([]);
+        setDetailError(null);
         return;
       }
 
       setDetailLoading(true);
+      setDetailError(null);
       try {
         const params = new URLSearchParams({
           session_id: selectedSession,
@@ -95,7 +98,7 @@ export default function CoreSessionsPage() {
         }
       } catch (loadError) {
         if (mounted) {
-          setError(
+          setDetailError(
             loadError instanceof Error
               ? loadError.message
               : "Failed to load session memories.",
@@ -164,6 +167,8 @@ export default function CoreSessionsPage() {
             <p className="muted">{selectedSession || "No session selected."}</p>
             {detailLoading ? (
               <div className="note">Loading session memories…</div>
+            ) : detailError ? (
+              <div className="error">{detailError}</div>
             ) : !memories.length ? (
               <div className="empty">No memories found for the selected session.</div>
             ) : (

--- a/apps/web/lib/proxy.ts
+++ b/apps/web/lib/proxy.ts
@@ -58,7 +58,15 @@ function buildTargetUrl(kind: ProxyKind, request: NextRequest, path: string[]): 
   const baseUrl = new URL(getBaseUrl(kind));
   const safePath = path.map((segment) => encodeURIComponent(segment)).join("/");
   const basePath = baseUrl.pathname.replace(/\/$/, "");
-  baseUrl.pathname = `${basePath}/${safePath}`.replace(/\/+/g, "/");
+  let targetPath = `${basePath}/${safePath}`.replace(/\/+/g, "/");
+
+  // Core exposes the collection list route at /memories/, and dropping the
+  // trailing slash causes an upstream redirect loop through the proxy.
+  if (kind === "core" && safePath === "memories") {
+    targetPath = `${targetPath}/`;
+  }
+
+  baseUrl.pathname = targetPath;
   baseUrl.search = request.nextUrl.search;
   return baseUrl;
 }


### PR DESCRIPTION
## Summary
Fixes the Core Sessions partial-load bug where the page rendered session inventory successfully but still showed a top-level `Load failed` banner.

## Root Cause
- The Core proxy normalized the collection route to `/memories` instead of `/memories/`, which caused a redirect loop on the selected-session memories request.
- The Sessions page used one shared error state for both the primary sessions inventory fetch and the secondary selected-session memories fetch, so a detail-panel failure surfaced as a page-global failure.

## Fix
- Preserve the trailing slash for the Core memories collection route in the Next proxy.
- Split the sessions page error handling so only the primary sessions fetch drives the top-level load state, while selected-session memory failures render in the detail panel only.

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Live proxy check: `/api/core/memories?session_id=agent:chat:main&limit=20&offset=0` now returns `200` instead of redirecting.
- Browser check: `/core/sessions` renders session inventory and selected-session memories without a global error banner.
- Forced failure check: the selected-session panel shows a local error while the page remains rendered.
