### PR TITLE
[codex] align architecture and operator docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ test_chroma_db/
 site/
 docs/domain-operations.md
 docs/website-routing.md
+docs/codex-rehydration-prompt.md
 
 # Runtime env
 .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,8 @@ The format is based on Keep a Changelog and this project follows SemVer.
 
 ## [Unreleased]
 
-### Added
-- Placeholder for new features.
-
 ### Changed
-- Placeholder for behavior changes.
-
-### Fixed
-- Placeholder for bug fixes.
+- Documentation updated to reflect the repo-root launcher, current track boundaries, current CI checks, and the canonical `statelock-engine` repo path.
 
 ## [0.3.0] - 2026-02-17
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ StateLock handles memory persistence/retrieval. It does **not** route model call
 - Agent runtime: OpenClaw
 - Durable memory: StateLock
 
+The repo currently uses a two-track architecture:
+
+- Core Track: stable Chroma-backed memory sidecar runtime
+- Observability Track: isolated conversation/telemetry/governance subsystem under `experimental/observability/`
+
+See `docs/architecture-tracks.md` for the current boundary.
+
 ## Features
 
 - Session-scoped memory blocks (`session_id`)
@@ -31,7 +38,7 @@ StateLock handles memory persistence/retrieval. It does **not** route model call
 - Optional API auth (`X-Statelock-Api-Key`) controlled by env
 - Health endpoints (`/healthz`, `/readyz`)
 
-## Quickstart (Local)
+## Quickstart (Core Only)
 
 ```bash
 python3 -m venv .venv
@@ -41,7 +48,7 @@ cp .env.example .env
 make run
 ```
 
-## Local Launcher (Recommended)
+## Local Launcher (Recommended Full Stack)
 
 Once the existing local environments are set up, you can run the full local stack
 from repo root with one command:
@@ -82,7 +89,7 @@ Runtime artifacts are stored locally in `.run/`:
 - PID files: `.run/*.pid`
 - logs: `.run/logs/*.log`
 
-The launcher keeps the existing manual startup flow intact and only adds a simpler
+The launcher keeps the existing manual startup flow intact and adds a simpler
 repo-root path for local developer/operator use.
 
 API docs:
@@ -129,6 +136,8 @@ Example:
 See:
 
 - `docs/run-with-local-first-stack.md`
+- `docs/local-stack.md`
+- `docs/local-stack-minimal.md`
 - `examples/openclaw-tooling/`
 - `examples/openclaw-tooling/openclaw-runtime/`
 - `examples/openclaw-tooling/AUTOMATION_CONTRACT.md`
@@ -163,7 +172,13 @@ Cloudflare domain strategy, redirect policy, and DNS/email templates:
 
 ## Website (Static v1)
 
-The public website lives in:
+Website ops docs in this repo live under:
+
+- `docs/domain-operations.md`
+- `docs/website-routing.md`
+- `infra/cloudflare/`
+
+A local-only static website worktree may also exist at:
 
 - `site/`
 
@@ -185,9 +200,14 @@ Cloudflare Pages deployment defaults:
 ```bash
 make lint
 make test
+make web-check
 ```
 
-CI runs both lint and tests.
+CI runs:
+
+- core lint + tests
+- web lint + typecheck + build when `apps/web` is present
+- observability tests in a separate workflow when `experimental/observability/**` changes
 
 ## Operations
 

--- a/docs/architecture-continuity-layer.md
+++ b/docs/architecture-continuity-layer.md
@@ -1,0 +1,496 @@
+# StateLock Continuity Layer Architecture
+
+## 1. Executive Summary
+
+The revised interpretation is **correct**:
+
+- **Core Track** should remain the stable memory sidecar runtime.
+- **Observability Track** should own conversation-centric capabilities such as ingestion, transcript normalization, working-context construction, telemetry, governance, distillation, and provenance relationships.
+- **External adapters** such as OpenClaw integrations, agent runtimes, and CLI helpers should consume existing Core memory APIs and selected Observability context/inspection APIs rather than introducing a new first-class `/gateway/*` subsystem inside Core.
+
+This interpretation matches the repository’s current two-track architecture and current runtime role separation.
+
+Evidence:
+
+- [`docs/architecture-tracks.md`](../docs/architecture-tracks.md) lines 3-6:
+  > Core Track: canonical runtime for memory sidecar operations.
+  > Observability Track: subsystem for agent execution state, traceability, and governance.
+- [`README.md`](../README.md) lines 3-17:
+  > StateLock Engine is a self-hosted memory sidecar API … StateLock handles memory persistence/retrieval. It does not route model calls.
+- [`docs/local-stack.md`](../docs/local-stack.md):
+  > LiteLLM = model router/switchboard.
+  > StateLock = memory/continuity sidecar.
+  > StateLock itself remains separate from model routing.
+
+## 2. Current Two-Track Architecture
+
+The repo is explicitly organized around two tracks.
+
+### Core Track
+
+Core is the canonical runtime for:
+
+- memory block storage and retrieval
+- `/memories/*` APIs
+- insights endpoints
+- health/readiness
+- Chroma-backed persistence
+
+Evidence:
+
+- [`docs/architecture-tracks.md`](../docs/architecture-tracks.md) lines 14-24
+- [`main.py`](../main.py) lines 20-27
+- [`app/core/database.py`](../app/core/database.py) lines 10-20
+- [`app/routers/memories.py`](../app/routers/memories.py) lines 29-99
+- [`app/routers/insights.py`](../app/routers/insights.py) lines 14-39
+
+### Observability Track
+
+Observability is the isolated subsystem for:
+
+- conversations, turns, spans
+- working-context construction
+- telemetry and explainability
+- governance and auditability
+- conversation import/export bundles
+- distillation and traceability
+
+Evidence:
+
+- [`docs/architecture-tracks.md`](../docs/architecture-tracks.md) lines 25-34
+- [`docs/architecture-tracks.md`](../docs/architecture-tracks.md) lines 36-42
+- [`experimental/observability/README.md`](../experimental/observability/README.md) lines 13-20
+- [`experimental/observability/app/main.py`](../experimental/observability/app/main.py) lines 42-55
+
+## 3. Role of Core Track
+
+Core’s role is to be the **stable memory sidecar runtime**.
+
+That currently includes:
+
+- memory block storage in Chroma
+- CRUD/query/upsert over memory blocks
+- session-scoped snapshots and restore
+- session/tag/stats insights
+- health and readiness
+
+Evidence:
+
+- [`README.md`](../README.md) lines 19-32 list current Core features including:
+  - session-scoped memory blocks
+  - CRUD and semantic query
+  - idempotent upsert
+  - session snapshot/restore
+  - health endpoints
+- [`app/services/memory_service.py`](../app/services/memory_service.py) lines 98-166 implement add/upsert
+- [`app/services/memory_service.py`](../app/services/memory_service.py) lines 167-257 implement query/hybrid query
+- [`app/services/memory_service.py`](../app/services/memory_service.py) lines 375-421 implement snapshot/restore
+- [`app/models/schemas.py`](../app/models/schemas.py) lines 99-146 define snapshot, restore, sessions, tags, and stats response models
+
+Core is **not** currently responsible for:
+
+- normalized transcript ingestion
+- archive bundles
+- working-context assembly
+- gateway routing
+- telemetry/governance
+
+Evidence:
+
+- [`examples/real-llm-smoke/README.md`](../examples/real-llm-smoke/README.md) lines 10-15:
+  > Core Track does not provide a working-context endpoint, so context assembly is intentionally emulated in the script.
+- [`README.md`](../README.md) line 11:
+  > It does not route model calls.
+
+## 4. Role of Observability Track
+
+Observability is where the repo already places most conversation-level continuity mechanics.
+
+That includes:
+
+- conversation lifecycle and settings
+- conversation import/export bundles
+- turn and span modeling
+- working-context construction
+- telemetry snapshots and explainability
+- governance actions
+- memory distillation
+
+Evidence:
+
+- [`experimental/observability/app/api/conversations.py`](../experimental/observability/app/api/conversations.py) lines 18-31 create conversations
+- [`experimental/observability/app/api/conversations.py`](../experimental/observability/app/api/conversations.py) lines 40-62 implement import/export
+- [`experimental/observability/app/api/context.py`](../experimental/observability/app/api/context.py) lines 16-46 implement working-context build/latest
+- [`experimental/observability/app/api/telemetry.py`](../experimental/observability/app/api/telemetry.py) lines 25-132 implement telemetry capture and explainability
+- [`experimental/observability/app/api/governance.py`](../experimental/observability/app/api/governance.py) lines 16-56 implement governance actions/logging
+- [`experimental/observability/app/api/memory.py`](../experimental/observability/app/api/memory.py) lines 16-45 implement memory listing and distillation
+- [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py) lines 135-200 show the actual working-context builder
+- [`experimental/observability/app/memory/distill.py`](../experimental/observability/app/memory/distill.py) lines 88-158 show the distillation pipeline
+
+This means the following interpretation is correct:
+
+- conversation ingestion belongs primarily to **Observability**
+- transcript normalization belongs primarily to **Observability**
+- working-context construction belongs primarily to **Observability**
+- execution tracing/telemetry belongs primarily to **Observability**
+- governance belongs primarily to **Observability**
+- memory distillation belongs primarily to **Observability**
+- provenance relationships should be defined first in **Observability**, then projected outward only if needed
+
+## 5. How the Continuity Layer Emerges
+
+The long-term “continuity layer” should be understood as an **emergent composition** of both tracks, not as an immediate rewrite of Core.
+
+Practical interpretation:
+
+- **Core** provides durable memory block storage and retrieval.
+- **Observability** provides conversation structure, continuity construction, distillation, provenance, and replay-oriented analysis.
+- **Adapters/examples** connect agents to one or both tracks depending on need.
+
+That makes the continuity layer:
+
+1. durable memory in Core,
+2. conversation-state and context assembly in Observability,
+3. adapter integration at the edge.
+
+This is already how the repo behaves in practice.
+
+Evidence:
+
+- [`examples/agent-memory-loop/README.md`](../examples/agent-memory-loop/README.md) lines 3-11 show Core-only memory-sidecar continuity
+- [`examples/real-llm-smoke/README.md`](../examples/real-llm-smoke/README.md) lines 3-8 show Core plus script-side context assembly
+- [`experimental/observability/README.md`](../experimental/observability/README.md) lines 13-20 show the richer conversation-continuity mechanics living in Observability
+
+## 6. Adapter Integration Model (OpenClaw, agents)
+
+External integrations should remain **adapter-style consumers** of StateLock capabilities.
+
+### Recommended model
+
+- Use Core memory APIs for save/query/session operations
+- Use Observability context APIs when a richer conversation-level context model is needed
+- Keep model invocation and routing outside StateLock
+
+### Why
+
+- This matches the current local stack separation:
+  - Ollama = local model runtime
+  - LiteLLM = model router
+  - StateLock = continuity/memory system using LiteLLM
+
+Evidence:
+
+- [`docs/local-stack.md`](../docs/local-stack.md) lines 15-24
+- [`docs/local-stack.md`](../docs/local-stack.md) lines 110-119
+
+### OpenClaw-specific recommendation
+
+OpenClaw should continue to start as **example integration and tool contract**, not as a first-class internal gateway module.
+
+Evidence:
+
+- [`docs/run-with-local-first-stack.md`](../docs/run-with-local-first-stack.md) lines 36-43 define tool wrappers:
+  - `memory.save`
+  - `memory.query`
+  - `memory.clear_session`
+- [`examples/openclaw-tooling/README.md`](../examples/openclaw-tooling/README.md) lines 3-11 define the same surface
+- [`examples/openclaw-tooling/AUTOMATION_CONTRACT.md`](../examples/openclaw-tooling/AUTOMATION_CONTRACT.md) lines 5-30 and 42-79 define pre-model/post-model hook contracts
+- [`examples/openclaw-tooling/AUTOMATION_CONTRACT.md`](../examples/openclaw-tooling/AUTOMATION_CONTRACT.md) line 98:
+  > Cloud escalation remains in agent/router layer; `confidence_low` is only a hint signal.
+
+### Conclusion
+
+The following statement is correct:
+
+> OpenClaw, agents, CLI tools, and example adapters should interact with StateLock through existing memory APIs or Observability context APIs, not through a new `/gateway/*` subsystem.
+
+## 7. Conversation Import Architecture
+
+Conversation import should be treated as an **Observability-first ingestion capability**.
+
+### Why
+
+- Observability already owns conversations, turns, spans, working context, telemetry, and distillation.
+- Observability already has import/export bundle support.
+- Core’s current data model is memory-block-oriented, not transcript-oriented.
+
+Evidence:
+
+- [`experimental/observability/app/api/conversations.py`](../experimental/observability/app/api/conversations.py) lines 40-62
+- [`experimental/observability/app/services/export_import.py`](../experimental/observability/app/services/export_import.py) lines 71-121 and 124-260
+- [`app/services/memory_service.py`](../app/services/memory_service.py) lines 98-166 and 375-421
+
+### Recommended structure
+
+Import architecture should initially mean:
+
+1. external export file
+2. parser/normalizer
+3. normalized conversation bundle
+4. Observability import
+5. optional distillation into Observability memory
+6. optional later projection into Core memory blocks
+
+### Raw archive store classification
+
+The “raw archive store” concept is worth preserving, but it should be classified as:
+
+- **future design track**
+- likely owned adjacent to **Observability ingestion**
+- not an immediate Core subsystem
+
+Current repo evidence:
+
+- no root `app/importers/`
+- no archive tree like `archive/platform/conversation_id/raw.json`
+- no current raw archive store implementation
+
+Command evidence:
+
+```text
+$ rg -n "archive/|Raw Archive Store|raw.json|normalized.json" .
+[no relevant matches]
+```
+
+## 8. Provenance and Distillation Model
+
+The right long-term model is:
+
+- imported conversation artifacts
+- distilled observations/memory entries
+- optional projection into Core memory blocks
+
+Observability already has part of this.
+
+Evidence:
+
+- [`experimental/observability/app/memory/distill.py`](../experimental/observability/app/memory/distill.py) lines 121-123 record:
+  - `source_turn_ids_json`
+  - `source_span_ids_json`
+- [`experimental/observability/app/services/export_import.py`](../experimental/observability/app/services/export_import.py) lines 244-260 preserve span provenance and relationships on import
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py) includes provenance-related JSON fields on spans
+
+### Stable interface to define next: provenance link model
+
+Suggested minimum shape:
+
+```json
+{
+  "origin_type": "imported|native|distilled",
+  "source_platform": "chatgpt|claude|markdown|telegram|discord|whatsapp|manual",
+  "conversation_id": "uuid",
+  "source_turn_ids": ["..."],
+  "source_span_ids": ["..."],
+  "observability_memory_id": "uuid|null",
+  "core_memory_block_id": "string|null"
+}
+```
+
+This keeps provenance explicit without forcing Core to own transcript-level history.
+
+## 9. Long-Term Promotion Path (Observability → Core)
+
+Promotion should be **incremental**, preserving subsystem coherence.
+
+That means:
+
+1. keep conversation-centric capabilities isolated under `experimental/observability/`
+2. stabilize interfaces and schemas first
+3. promote cohesive modules later into a future `app/observability/` namespace
+4. do **not** scatter context/import/distillation concerns across root `app/` prematurely
+
+Evidence:
+
+- [`docs/architecture-tracks.md`](../docs/architecture-tracks.md) lines 44-62 define the post-promotion target structure:
+  ```text
+  app/
+    core/
+      memories/
+      storage/
+      insights/
+
+    observability/
+      conversations/
+      spans/
+      telemetry/
+      governance/
+  ```
+  and state:
+  > Promotion is incremental and must preserve subsystem coherence; observability components should not be scattered across unrelated directories.
+
+### Continuity-layer interpretation of promotion
+
+Long term, the continuity layer may become more unified conceptually, but the **promotion path should still respect current ownership**:
+
+- Core remains the durable memory runtime
+- Observability becomes the promoted conversation/traceability subsystem
+- adapters remain outside the backend core path
+
+## 10. Deferred Design Tracks (crypto, PQC, encrypted archives)
+
+Crypto and PQC should be treated as **deferred design tracks**, not immediate implementation steps.
+
+### Why
+
+- There is no current repo evidence for:
+  - AES-at-rest implementation
+  - PQC key wrapping
+  - signed archive bundles
+  - root `app/security/`
+
+Command evidence:
+
+```text
+$ rg -n "ML-KEM|ML-DSA|SLH-DSA|AES-256-GCM|wrapped_key|signature.sig|app/security" .
+[no relevant matches]
+```
+
+### What should be preserved from the earlier proposal
+
+#### Raw archive store
+
+- **Preserve conceptually**
+- classify as **future design track**
+- likely adjacent to Observability ingestion
+
+#### Distillation pipeline
+
+- **Already exists**
+- primarily **belongs to Observability**
+
+Evidence:
+
+- [`experimental/observability/app/memory/distill.py`](../experimental/observability/app/memory/distill.py)
+
+#### Context builder
+
+- **Already exists**
+- primarily **belongs to Observability**
+
+Evidence:
+
+- [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py)
+
+#### Gateway adapters
+
+- **Preserve conceptually**
+- but classify as **external adapter contract**, not Core backend subsystem
+
+Evidence:
+
+- [`examples/openclaw-tooling/README.md`](../examples/openclaw-tooling/README.md)
+- [`examples/openclaw-tooling/AUTOMATION_CONTRACT.md`](../examples/openclaw-tooling/AUTOMATION_CONTRACT.md)
+
+#### Encrypted export bundles
+
+- **Future design track**
+- worth documenting later once import/archive formats stabilize
+
+## Near-Term Design Note
+
+Two follow-on design tracks are consistent with this architecture and should remain
+Observability-led rather than Core-led:
+
+1. **Experience / procedural memory extraction**
+2. **Memory stratification across raw, working, semantic, episodic, and procedural layers**
+
+These are documented in:
+
+- [`docs/statelock-cognitive-architecture.md`](../docs/statelock-cognitive-architecture.md)
+- [`docs/architecture-memory-stratification.md`](../docs/architecture-memory-stratification.md)
+
+This note is intentionally short to avoid duplicating the detailed layering and
+experience-model discussion in those focused documents.
+
+The corresponding promotion/routing design is documented in:
+
+- [`docs/architecture-promotion-engine.md`](../docs/architecture-promotion-engine.md)
+- [`docs/architecture-memory-graph.md`](./architecture-memory-graph.md)
+
+## Stable Interfaces To Define Next
+
+### Interface 1: Normalized conversation bundle schema
+
+Purpose:
+
+- unify imported conversation formats before ingestion
+
+Recommended owner:
+
+- Observability
+
+Reason:
+
+- import/export already exists there
+
+Starting shape:
+
+```json
+{
+  "bundle_version": "statelock_bundle_v1",
+  "source_platform": "chatgpt|claude|markdown|telegram|discord|whatsapp",
+  "conversation": {
+    "external_id": "string",
+    "title": "string",
+    "created_at": "iso8601"
+  },
+  "turns": [
+    {
+      "turn_id": "string",
+      "speaker": "user|assistant|system|tool",
+      "text": "string",
+      "created_at": "iso8601",
+      "metadata": {}
+    }
+  ]
+}
+```
+
+### Interface 2: Provenance link model
+
+Purpose:
+
+- connect imported conversations, distilled observations, and Core memory blocks
+
+Recommended owner:
+
+- Observability first
+
+Reason:
+
+- it already carries source-turn/source-span lineage
+
+Suggested shape:
+
+```json
+{
+  "origin_type": "imported|native|distilled",
+  "source_platform": "chatgpt|claude|markdown|telegram|discord|whatsapp|manual",
+  "conversation_id": "uuid",
+  "source_turn_ids": ["..."],
+  "source_span_ids": ["..."],
+  "observability_memory_id": "uuid|null",
+  "core_memory_block_id": "string|null"
+}
+```
+
+### Interface 3: External adapter contract
+
+Purpose:
+
+- let OpenClaw-style systems consume StateLock capabilities without turning StateLock into a model router
+
+Recommended owner:
+
+- examples/contracts first, later formal docs
+
+Minimal contract:
+
+- memory query
+- memory save
+- clear session
+- optional Observability working-context lookup
+
+This is already close to the current tool contract in:
+
+- [`examples/openclaw-tooling/AUTOMATION_CONTRACT.md`](../examples/openclaw-tooling/AUTOMATION_CONTRACT.md)

--- a/docs/architecture-memory-graph.md
+++ b/docs/architecture-memory-graph.md
@@ -1,0 +1,518 @@
+# StateLock Memory Graph Architecture
+
+## 1. Executive Summary
+
+The **Memory Graph** concept is both **sound** and **useful**, as long as it is framed correctly:
+
+- it should **not** replace Core memory blocks,
+- it should **not** replace vector retrieval,
+- and it should live **primarily in Observability**, not in Core.
+
+Repo-aligned interpretation:
+
+- **Core** remains the stable memory sidecar runtime for durable semantic memory blocks stored and queried through the existing Chroma-backed APIs.
+- **Observability** is the natural home for richer graph structures because it already owns conversations, turns, spans, working context, provenance, contradictions, telemetry, governance, distillation, and promotion records.
+- The first useful graph should be treated as a **relationship/provenance structure** backing continuity and promotion, not as a “full knowledge graph platform”.
+
+Evidence:
+
+- [`README.md`](../README.md#L3) defines StateLock as a memory sidecar and says it does not route model calls.
+- [`docs/architecture-tracks.md`](./architecture-tracks.md#L14) assigns Core to memory block storage/retrieval and Observability to traceability/governance.
+- [`app/models/schemas.py`](../app/models/schemas.py#L8) and [`app/services/memory_service.py`](../app/services/memory_service.py#L98) show Core’s memory contract is intentionally simple and not graph-oriented.
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L46) already contains graph-like link fields on spans (`semantic_neighbors_json`, `provenance_json`, `contradictions_json`).
+
+## 2. Why a Memory Graph Is Worth Considering
+
+Vector memory and graph structure solve different problems.
+
+Vector memory is good for:
+
+- fuzzy recall
+- semantic similarity
+- approximate retrieval across wording variation
+
+Graph structure is good for:
+
+- provenance neighborhoods
+- contradiction neighborhoods
+- relationship-aware expansion
+- episodic linkage
+- promotion lineage
+- structured continuity around entities, projects, decisions, and runs
+
+The repo already hints at this split:
+
+- Core hybrid query is still fundamentally a similarity/recency recall system ([`app/services/memory_service.py`](../app/services/memory_service.py#L167))
+- Observability already expands selected context via provenance links, which is graph-like behavior ([`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py#L67))
+
+That makes the strongest architecture:
+
+- **vector memory = recall engine**
+- **graph memory = structure engine**
+
+## 3. Current Repo Reality and Existing Relevant Structures
+
+### Core today
+
+Core stores independent memory blocks with a narrow schema:
+
+- `content`
+- `name`
+- `session_id`
+- `tags`
+- timestamps
+- deterministic IDs via `external_id`
+
+Evidence:
+
+- [`app/models/schemas.py`](../app/models/schemas.py#L8)
+- [`app/services/memory_service.py`](../app/services/memory_service.py#L103)
+
+Important implication:
+
+Core does **not** currently model:
+
+- entities
+- relationships
+- provenance edges
+- contradiction graphs
+- decision lineage
+
+### Observability today
+
+Observability already has several graph-like structures, even though they are not formalized as a graph subsystem:
+
+- conversations link turns
+- turns link to spans via `source_turn_ids_json`
+- spans link to other spans via:
+  - `semantic_neighbors_json`
+  - `provenance_json`
+  - `contradictions_json`
+- working contexts select span sets
+- telemetry snapshots link runs to turns and selected spans
+- memory entries link back to source turns and spans
+
+Evidence:
+
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L31)
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L46)
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L81)
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L95)
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L112)
+
+The context builder already uses these links operationally:
+
+- it selects procedural memory
+- scores spans
+- expands the selected set through provenance links
+
+Evidence:
+
+- [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py#L40)
+- [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py#L67)
+- [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py#L198)
+
+Additional evidence:
+
+- serializers already expose span links as a `links` object with `semantic_neighbors`, `provenance`, and `contradictions` in [`experimental/observability/app/services/serializers.py`](../experimental/observability/app/services/serializers.py#L119)
+- the Observability repo guide already describes spans as having trust/provenance/thread assignment and the context builder as expanding via provenance links in [`experimental/observability/docs/REPO_GUIDE.md`](../experimental/observability/docs/REPO_GUIDE.md#L53) and [`experimental/observability/docs/REPO_GUIDE.md`](../experimental/observability/docs/REPO_GUIDE.md#L72)
+
+### Repo-aligned conclusion
+
+Implemented now:
+
+- **partial graph-like structures in Observability**
+
+Missing now:
+
+- explicit graph schema
+- explicit node/edge types
+- promotion/projection lineage graph
+
+## 4. Why Graphs Are Different from Memory Blocks
+
+Core memory blocks answer:
+
+- “What durable fact-like content should be stored and retrieved?”
+
+Graphs answer:
+
+- “How do artifacts relate?”
+- “What was derived from what?”
+- “Which items contradict or reinforce each other?”
+- “Which episode produced this memory?”
+- “Which project, tool, user, or decision neighborhood does this belong to?”
+
+That difference matters because the current architecture already assumes:
+
+- Core should stay narrow and boring
+- Observability should carry richer continuity structure
+
+A graph is therefore best understood as:
+
+- a **relationship layer** above raw artifacts and memory entries,
+- not a replacement for durable memory blocks.
+
+## 5. Hybrid Model: Vector Recall + Graph Structure
+
+Recommended hybrid model:
+
+1. **Vector recall**
+   - find semantically relevant blocks or entries
+2. **Graph expansion**
+   - follow important links such as provenance, contradiction, episode, applies-to, or supersession
+3. **Selection/promotion logic**
+   - decide what enters working context, what is reinforced, and what should project into Core
+
+Repo grounding:
+
+- Core already covers vector-like retrieval through Chroma and hybrid query ([`app/services/memory_service.py`](../app/services/memory_service.py#L167))
+- Observability already covers relationship-aware context expansion through provenance links ([`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py#L67))
+
+Therefore:
+
+- **do not replace Core retrieval with a graph**
+- **do not force Core to become graph-native**
+- **use graph structure mainly inside Observability**
+
+## 6. Candidate Graph Node Types
+
+Recommended early node types:
+
+### Graph-native now or soon
+
+- `conversation`
+- `turn`
+- `span`
+- `thread`
+- `working_context`
+- `telemetry_snapshot`
+- `memory_entry`
+- `promotion_artifact` (future schema layer)
+- `promotion_decision` (future schema layer)
+- `projection_record` (future schema layer)
+
+These are repo-aligned because close equivalents already exist in Observability.
+
+Evidence:
+
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L16)
+- [`docs/architecture-promotion-schemas.md`](./architecture-promotion-schemas.md#L131)
+
+### Useful conceptual node types after the first phase
+
+- `entity` (user, agent, team, system, tool)
+- `project`
+- `episode`
+- `document`
+- `decision`
+- `constraint`
+
+These are useful, but most are **conceptual/future** because the repo does not yet have first-class models for them.
+
+### Core-specific note
+
+Core memory blocks can appear as **referenced nodes** through `ProjectionRecord`, but Core itself should not become the owner of a graph subsystem in the first phase.
+
+## 7. Candidate Relationship Types
+
+The most useful early relationship types are the ones already implied by current data or immediately required by promotion/provenance.
+
+### High-value early relationships
+
+- `derived_from`
+- `produced_by`
+- `belongs_to`
+- `applies_to`
+- `contradicts`
+- `reinforces`
+- `supersedes`
+- `used_in_context`
+- `selected_for`
+- `projected_to_core`
+
+### Why these matter
+
+- `derived_from` captures provenance and distillation lineage
+- `contradicts` captures conflict neighborhoods
+- `supersedes` captures retirement/deprecation chains
+- `projected_to_core` makes the Observability → Core boundary explicit
+
+### Repo evidence
+
+Existing nearby structures:
+
+- `provenance_json` on spans maps naturally to `derived_from`
+- `contradictions_json` maps naturally to `contradicts`
+- `source_turn_ids_json` / `source_span_ids_json` on memory entries map naturally to `derived_from`
+- `selected_span_ids_json` on working contexts maps naturally to `selected_for` / `used_in_context`
+
+Evidence:
+
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L62)
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L88)
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L125)
+- [`experimental/observability/app/services/serializers.py`](../experimental/observability/app/services/serializers.py#L119)
+
+## 8. Provenance on Nodes and Edges
+
+Provenance should attach to both nodes and edges.
+
+### Node-level provenance
+
+Useful for:
+
+- who/what created the node
+- source conversation/run/session
+- summary trust and timestamps
+
+### Edge-level provenance
+
+Useful for:
+
+- why the relationship exists
+- what evidence supports it
+- whether it came from heuristic logic, distillation, telemetry, or human review
+- whether the link is disputed, superseded, or high-confidence
+
+Repo-aligned recommendation:
+
+- keep provenance rich on the Observability side
+- keep Core-side provenance minimal and indirect via `ProjectionRecord`
+
+Why:
+
+- Core has no rich provenance schema slots today
+- Observability already has the richer structures and is the right owner
+
+## 9. How Graphs Fit the Stratified Memory Model
+
+Not every memory layer benefits equally from graph structure.
+
+### Layer 0: Raw Archive
+
+Graph usefulness: **high**
+
+Why:
+
+- conversations, turns, spans, logs, and tool traces form natural linked neighborhoods
+
+Repo status:
+
+- partially represented in Observability now
+
+### Layer 1: Working Memory
+
+Graph usefulness: **medium to high**
+
+Why:
+
+- working context benefits from neighborhood expansion and structured selection
+
+Repo status:
+
+- already partly graph-like via provenance expansion
+
+### Layer 2: Durable Semantic Memory
+
+Graph usefulness: **low to medium inside Core**
+
+Why:
+
+- Core’s main job is durable recall, not relationship traversal
+- some relationship awareness may be helpful, but should stay outside Core initially
+
+Repo status:
+
+- Core currently stores flat blocks only
+
+### Layer 3: Episodic Memory
+
+Graph usefulness: **high**
+
+Why:
+
+- episodes are inherently linked to people, projects, incidents, and derived lessons
+
+Repo status:
+
+- only partially represented today
+
+### Layer 4: Procedural / Experience Memory
+
+Graph usefulness: **high**
+
+Why:
+
+- strategies often apply to entities, tools, projects, and prior outcomes
+
+Repo status:
+
+- partially represented through procedural memory entries plus telemetry/governance counters
+
+### Layer 5: Policy / Constraints Layer
+
+Graph usefulness: **medium**
+
+Why:
+
+- constraints often apply to projects, agents, routes, or workflows
+
+Repo recommendation:
+
+- keep this mainly in docs/config/policy registries; do not treat it as ordinary Core memory
+
+## 10. How Graphs Fit the Promotion Engine and Projection Boundary
+
+The Memory Graph should support the Promotion Engine, not replace it.
+
+Recommended role:
+
+- graph neighborhoods provide context for promotion evidence
+- promotion decisions can create or update graph edges
+- `ProjectionRecord` becomes the explicit edge from Observability-owned promoted knowledge to a Core memory block
+
+Examples:
+
+- `promotion_artifact --derived_from--> span`
+- `promotion_artifact --derived_from--> telemetry_snapshot`
+- `promotion_decision --supported_by--> promotion_evidence`
+- `projection_record --projected_to_core--> core_memory_block`
+- `memory_entry --contradicts--> memory_entry`
+
+Repo-aligned conclusion:
+
+- graph structure belongs mostly in **Observability**
+- the Core boundary remains the reduced semantic projection described in [`docs/architecture-promotion-schemas.md`](./architecture-promotion-schemas.md#L412)
+
+## 11. What Should Stay Out of Core
+
+Core should not become the owner of:
+
+- graph traversal logic
+- provenance graphs
+- contradiction graphs
+- run/session trace graphs
+- promotion evidence graphs
+- episodic or procedural/experience relationship neighborhoods
+
+Why:
+
+- this would violate the existing Core vs Observability split
+- it would widen the Core runtime far beyond its current stable contract
+
+Evidence:
+
+- Core responsibilities in [`docs/architecture-tracks.md`](./architecture-tracks.md#L14)
+- Core memory schema in [`app/models/schemas.py`](../app/models/schemas.py#L8)
+
+The only justified Core role is:
+
+- continuing to store durable semantic blocks,
+- optionally referenced by graph edges on the Observability side.
+
+## 12. Minimal Viable Graph Schema
+
+A minimal useful graph schema should stay small.
+
+Recommended early shape:
+
+```yaml
+GraphNode:
+  node_id: string
+  node_type: string
+  owner_track: enum[core, observability]
+  ref_id: string
+  title: string | null
+  summary: string | null
+  status: string | null
+  created_at: datetime
+  updated_at: datetime | null
+  metadata: object
+
+GraphEdge:
+  edge_id: string
+  edge_type: string
+  src_node_id: string
+  dst_node_id: string
+  weight: float | null
+  confidence: float | null
+  status: string | null
+  provenance_refs: object
+  created_at: datetime
+  updated_at: datetime | null
+```
+
+### Why this is enough
+
+It supports:
+
+- relationship neighborhoods
+- provenance-aware traversal
+- contradiction/supersession chains
+- projection edges into Core
+
+without introducing a dedicated graph database or a bloated ontology.
+
+### Important constraint
+
+The earliest graph should be **Observability-owned**, with `owner_track = core` used only for referenced Core memory blocks or projections.
+
+## 13. Recommended Storage Strategy for Early Versions
+
+Early versions should use:
+
+- **SQLite node/edge tables or adjacency tables inside Observability**
+
+Not:
+
+- a dedicated graph backend
+- graph-native Core persistence
+
+Why:
+
+- Observability already uses SQLite-backed structured models
+- the graph can start as a small relationship layer adjacent to existing rows
+- this is lower-risk than introducing a new infrastructure dependency
+
+Repo evidence:
+
+- Observability models are already SQLAlchemy/SQLite-backed in [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L16)
+- no graph backend or graph service exists in the repo today
+
+Practical interpretation:
+
+- first phase: graph-ish adjacency tables in Observability
+- later phase: only consider a dedicated graph backend if real traversal/query needs justify it
+
+## 14. Recommended Implementation Sequence
+
+1. **Document the graph role**
+   - this document
+2. **Keep graph ownership in Observability**
+   - do not widen Core
+3. **Normalize existing implicit links**
+   - provenance, contradictions, semantic neighbors, source refs
+4. **Add minimal node/edge schema**
+   - enough for provenance and relationship neighborhoods
+5. **Connect graph edges to PromotionArtifact / PromotionDecision / ProjectionRecord**
+   - only after promotion schemas stabilize
+6. **Use graph for better context expansion and promotion analysis**
+   - before considering any graph-native runtime features
+7. **Evaluate whether Core needs any selective read-through later**
+   - default answer should remain “probably not”
+
+## 15. Open Questions
+
+1. Should the first graph schema model only Observability-native nodes, with Core blocks represented only through `ProjectionRecord`, or should Core blocks become direct node refs from the start?
+2. Should graph edges be explicit first-class rows, or should the first version normalize only the existing span/memory link fields into a common read model?
+3. Which entity nodes are worth first-class promotion earliest: user, agent, project, tool, or decision?
+4. Should episodic clusters be explicit graph nodes, or remain inferred from conversation/thread neighborhoods at first?
+5. When contradiction exists between semantic/procedural memories, should the graph store both the contradiction edge and the supersession edge, or only one plus status?
+
+## Cross-Reference
+
+- Stratified memory model: [`docs/architecture-memory-stratification.md`](./architecture-memory-stratification.md)
+- Promotion engine: [`docs/architecture-promotion-engine.md`](./architecture-promotion-engine.md)
+- Promotion boundary schemas: [`docs/architecture-promotion-schemas.md`](./architecture-promotion-schemas.md)
+- Track ownership and continuity framing: [`docs/architecture-continuity-layer.md`](./architecture-continuity-layer.md)

--- a/docs/architecture-memory-policy-profiles.md
+++ b/docs/architecture-memory-policy-profiles.md
@@ -1,0 +1,473 @@
+# StateLock Memory Policy Profiles and Resource Budgets
+
+## 1. Executive Summary
+
+The **Memory Policy Profiles** concept is **sound and useful** for StateLock.
+
+The repo already has enough architectural separation to support this idea cleanly:
+
+- **Core** remains the stable memory sidecar runtime.
+- **Observability** remains the owner of richer continuity logic: context construction, telemetry, governance, distillation, promotion, provenance, and graph structure.
+- Policy profiles should therefore act mainly as **configuration and decision policy** over Observability behavior, with only narrow downstream effects on what eventually projects into Core.
+
+Repo-aligned interpretation:
+
+- profiles should shape **what is promoted, retained, summarized, expanded, reviewed, and retired**
+- profiles should **not** turn Core into a tunable continuity engine
+- profiles should be expressed as **small, understandable budget presets**, not a giant pile of hidden heuristics
+
+Evidence:
+
+- [`README.md`](../README.md#L3) defines StateLock as a memory sidecar and says it does not route model calls.
+- [`docs/architecture-tracks.md`](./architecture-tracks.md#L14) assigns Core to stable memory block operations and Observability to traceability/governance.
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L25) already carries continuity-related knobs such as `max_context_tokens`, `telemetry_mode`, `target_thread_mode`, and `pinned_thread_id`.
+- [`app/services/automation_policy.py`](../app/services/automation_policy.py#L31) already shows the repo is comfortable with explicit deterministic save policy logic rather than opaque automation.
+
+## 2. Why Memory Policy Profiles Matter
+
+StateLock should not have one fixed memory appetite.
+
+Different use cases want meaningfully different behavior:
+
+- a privacy-sensitive setup may want narrow retention and stricter review
+- a project-heavy workflow may want deeper continuity and more aggressive distillation
+- a low-resource laptop may want smaller recall and telemetry budgets
+- a long-running agent workflow may want heavier reinforcement and cleanup passes
+
+The important product framing is:
+
+- this is **not** just “how much memory file size is allowed”
+- this is a **policy and budget model** for continuity behavior
+
+That matches the repo better than a storage-only framing because many of the important knobs already sit above storage:
+
+- working-context size (`max_context_tokens`)
+- telemetry mode
+- trust and quarantine signals
+- distillation and procedural memory
+- reinforcement/deprecation counters
+
+Evidence:
+
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L25)
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L57)
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L123)
+
+## 3. Current Repo Reality and Why This Is Mostly Future-Looking
+
+This design is mostly **future-looking**, but it is not disconnected from the repo.
+
+### Already implemented or partially represented
+
+- Core memory save/query/upsert and snapshot/restore
+- deterministic save triggers in `automation_policy`
+- Observability working-context token budget
+- telemetry mode and target-thread mode
+- procedural memory selection
+- reinforcement/deprecation-like signals via success/failure counters and statuses
+- graph-like provenance and contradiction links
+
+Evidence:
+
+- [`app/services/memory_service.py`](../app/services/memory_service.py#L98)
+- [`app/services/automation_policy.py`](../app/services/automation_policy.py#L9)
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L25)
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L123)
+- [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py#L40)
+
+### Not implemented yet
+
+- named policy profiles
+- a unified budget model
+- explicit retention/decay policies
+- background introspection/cleanup scheduling
+- graph-expansion profiles
+- profile-scoped promotion thresholds
+
+So the correct framing is:
+
+- **conceptually sound**
+- **repo-aligned**
+- **mostly future**
+
+## 4. Policy Profiles vs Ordinary User Preferences
+
+These should not be treated as the same thing.
+
+### Ordinary user preferences
+
+Examples:
+
+- tone preferences
+- stylistic instructions
+- domain preferences
+- durable personal/project facts
+
+Those are memory-like content and may eventually project into Core as durable semantic memory.
+
+### Policy profiles
+
+Examples:
+
+- how aggressively to promote memory
+- how much context to retrieve
+- how deep graph expansion should go
+- how much telemetry to retain
+- when review is required
+- how frequently cleanup or consolidation runs
+
+These are **system behavior controls**, not ordinary memory content.
+
+Recommended owner:
+
+- docs/config/runtime policy first
+- Observability decision logic second
+- Core only indirectly affected via fewer or more selective semantic projections
+
+## 5. Core Design Dimensions
+
+### 5.1 Storage budget
+
+Useful dimensions:
+
+- archive size / archive retention
+- durable memory count
+- graph node/edge volume
+- telemetry retention
+- export bundle size
+
+Repo alignment:
+
+- mostly future
+- should live mainly in Observability and export tooling
+
+Why:
+
+- Core today does not expose storage quotas or graph limits
+- Observability already owns most large structured artifacts
+
+### 5.2 Cognitive budget
+
+Useful dimensions:
+
+- distillation frequency
+- promotion aggressiveness
+- experience aggregation effort
+- contradiction resolution passes
+- introspection/cleanup frequency
+- summarization/consolidation frequency
+- graph extraction/expansion effort
+
+Repo alignment:
+
+- this is the most important conceptual budget family
+
+Why:
+
+- it directly affects continuity quality without requiring Core changes
+- it maps to Observability’s real responsibilities: distillation, promotion, telemetry, governance, and graph structure
+
+### 5.3 Recall budget
+
+Useful dimensions:
+
+- max retrieved memories
+- token budget for injected context
+- episodic expansion depth
+- graph traversal depth
+- provenance expansion limits
+
+Repo alignment:
+
+- partly represented already
+
+Evidence:
+
+- Core query top-k exists in [`app/models/schemas.py`](../app/models/schemas.py#L69)
+- Observability already stores `max_context_tokens` and uses bounded context assembly in [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L25) and [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py#L178)
+
+### 5.4 Retention / decay policy
+
+Useful dimensions:
+
+- confidence decay
+- archive TTL
+- episodic retention windows
+- procedural/experience reinforcement thresholds
+- auto-retirement / eviction rules
+
+Repo alignment:
+
+- partially represented
+
+Evidence:
+
+- `success_count`, `failure_count`, `last_applied_at`, and `status` on `MemoryEntry` already imply reinforcement/deprecation signals in [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L123)
+
+### 5.5 Review / safety policy
+
+Useful dimensions:
+
+- when human review is required
+- when policy/constraints candidates require confirmation
+- stricter promotion thresholds for privacy-focused profiles
+- stronger quarantine/deprecation thresholds under higher-risk profiles
+
+Repo alignment:
+
+- strongly aligned with existing governance/quarantine concepts
+
+Evidence:
+
+- span quarantine support in [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L64)
+- governance events in [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L132)
+- deterministic policy/save triggers in [`app/services/automation_policy.py`](../app/services/automation_policy.py#L9)
+
+## 6. Candidate Profiles
+
+Keep the profile set small and understandable.
+
+### Minimal
+
+Best for:
+
+- low-resource setups
+- shallow continuity
+- short-lived sessions
+
+Expected behavior:
+
+- narrow promotion
+- short recall/context budget
+- minimal graph expansion
+- low telemetry retention
+- minimal background cleanup work
+
+### Balanced
+
+Best for:
+
+- default developer/operator use
+
+Expected behavior:
+
+- moderate promotion thresholds
+- moderate recall/context budget
+- provenance-aware expansion, but shallow
+- moderate telemetry retention
+- periodic cleanup/consolidation
+
+Recommendation:
+
+- this should be the likely default profile if profiles are added later
+
+### Deep Continuity
+
+Best for:
+
+- long-running assistants
+- research copilots
+- continuity-heavy personal systems
+
+Expected behavior:
+
+- deeper graph/provenance expansion
+- more aggressive distillation and reinforcement
+- larger recall and context budgets
+- more retained telemetry and episodic structures
+- more periodic introspection and consolidation
+
+### Project-Focused
+
+Best for:
+
+- repo/project continuity
+- task and architecture memory
+
+Expected behavior:
+
+- favor project facts, decisions, and workflow procedures
+- promote project-specific semantic and procedural memory more readily
+- constrain recall toward project/session scope
+- de-emphasize broad personal/ambient memory
+
+### Privacy-Hardline
+
+Best for:
+
+- sensitive work
+- conservative retention
+
+Expected behavior:
+
+- stricter promotion thresholds
+- narrower retention windows
+- more human-gated promotion for policy/high-impact memories
+- weaker background aggregation
+- tighter archive and telemetry retention
+
+### Optional note on “Jarvis mode”
+
+“Jarvis mode” is worth documenting only as an **informal nickname** for a high-resource, high-continuity profile.
+
+It should **not** be the formal profile name.
+
+Why:
+
+- it sounds magical and ambiguous
+- it obscures the actual budget knobs that matter
+- “Deep Continuity” is clearer as an architecture/product term
+
+Recommended treatment:
+
+- formal profile name: `Deep Continuity`
+- optional informal description: “Jarvis-like behavior”
+
+## 7. Which Existing/Production Memory Ideas Are Worth Adopting
+
+Worth adopting because they align with transparency, provenance, and the current repo shape:
+
+- **confidence decay**
+  - useful for lowering stale or weakly reinforced memories over time
+- **contradiction tracking**
+  - already strongly foreshadowed by Observability span contradiction links
+- **importance / strength weighting**
+  - already partly present as `strength` on `MemoryEntry`
+- **summarization / consolidation**
+  - useful when done visibly and traceably
+- **scope-aware memory**
+  - highly compatible with session/conversation/project scoping
+- **reinforcement through repeated outcomes**
+  - already hinted by success/failure counters
+- **introspection / cleanup**
+  - useful if explicit, logged, and reviewable
+
+Evidence:
+
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L61)
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L123)
+- [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py#L67)
+- [`app/services/automation_policy.py`](../app/services/automation_policy.py#L31)
+
+## 8. Which Ideas Should Be Avoided
+
+These would make StateLock worse:
+
+- opaque black-box ranking with no inspectable reason path
+- silent mutation of durable memory with no provenance
+- silent deletion/retirement without auditability
+- unrestricted graph expansion that hides why context grew
+- a huge matrix of tiny knobs instead of a few understandable profiles
+- policy profiles masquerading as ordinary memory content
+- profile logic inside Core beyond narrow projection-side effects
+
+StateLock’s repo direction clearly favors:
+
+- explicit traceability
+- explicit governance
+- explicit sidecar contracts
+
+The profile system should preserve those values.
+
+## 9. How Policy Profiles Influence
+
+### Promotion engine
+
+Profiles should influence:
+
+- promotion thresholds
+- delayed vs immediate promotion preference
+- review requirements
+- reinforcement/deprecation sensitivity
+
+### Promotion schemas
+
+Profiles should influence:
+
+- decision mode defaults
+- review/safety state thresholds
+- projection aggressiveness
+
+They should **not** require changing the canonical schema shapes.
+
+### Memory stratification
+
+Profiles should influence:
+
+- which layers receive more or less attention
+- how readily episodic/procedural observations are retained
+- whether some layers are aggressively summarized or lightly retained
+
+### Memory graph
+
+Profiles should influence:
+
+- graph extraction effort
+- traversal depth
+- provenance expansion limits
+- contradiction-neighborhood exploration effort
+
+### Observability vs Core
+
+Profiles should mostly act on **Observability behavior**.
+
+Core should only feel them indirectly through:
+
+- fewer or more durable semantic projections
+- potentially narrower or broader retrieval defaults if later exposed
+
+That preserves the Core vs Observability split.
+
+## 10. What Should Be Configurable in Early Versions
+
+Recommended early configurable items:
+
+1. `max_context_tokens`
+2. promotion aggressiveness level
+3. graph/provenance expansion depth
+4. telemetry retention level
+5. review strictness level
+6. cleanup/consolidation cadence
+
+Why these first:
+
+- they map cleanly to current or adjacent repo concepts
+- they are understandable
+- they mostly live in Observability/configuration rather than requiring Core redesign
+
+Avoid early overexposure of:
+
+- dozens of per-axis weights
+- user-facing decay math knobs
+- low-level storage quotas
+
+## 11. Recommended Implementation Sequence
+
+1. **Document profile model first**
+   - this document
+2. **Define 3-5 named presets**
+   - no giant knob matrix
+3. **Attach presets to Observability continuity behavior**
+   - working-context build, promotion, review, retention
+4. **Add explicit logging of profile-driven decisions**
+   - preserve transparency
+5. **Only then add more advanced cleanup/decay logic**
+   - after reinforcement/deprecation flows stabilize
+6. **Keep Core changes minimal**
+   - ideally none beyond eventual consumption of projected semantic outputs
+
+## 12. Open Questions
+
+1. Should profiles be global, per conversation, per session, or all three?
+2. Which dimensions belong in the user-visible preset vs internal tuning values?
+3. Should `Project-Focused` be a standalone preset or a scope overlay on top of `Balanced` / `Deep Continuity`?
+4. When privacy and continuity goals conflict, should the profile enforce hard caps or only stronger review thresholds?
+5. Should introspection/cleanup run opportunistically after active sessions, or on an explicit maintenance pass only?
+
+## Cross-Reference
+
+- Stratified memory model: [`docs/architecture-memory-stratification.md`](./architecture-memory-stratification.md)
+- Promotion engine: [`docs/architecture-promotion-engine.md`](./architecture-promotion-engine.md)
+- Promotion schemas: [`docs/architecture-promotion-schemas.md`](./architecture-promotion-schemas.md)
+- Memory graph: [`docs/architecture-memory-graph.md`](./architecture-memory-graph.md)
+- Continuity framing: [`docs/architecture-continuity-layer.md`](./architecture-continuity-layer.md)

--- a/docs/architecture-memory-stratification.md
+++ b/docs/architecture-memory-stratification.md
@@ -1,0 +1,420 @@
+# StateLock Memory Stratification and Experience Layer
+
+## Executive Summary
+
+The proposed extension is **architecturally sound**, with two important clarifications:
+
+1. The **Experience Layer** fits naturally under `experimental/observability/`, not Core.
+2. **Memory stratification** is a strong conceptual model for StateLock, but several layers are still conceptual or only partially represented in the repo today.
+
+The repo already supports the underlying shape:
+
+- Core is a stable memory sidecar with durable memory blocks in Chroma.
+- Observability already models conversations, spans, working contexts, telemetry, governance, and distilled memory.
+- External adapters such as OpenClaw already operate through tool-style contracts rather than a new `/gateway/*` subsystem.
+
+Evidence:
+
+- [`README.md`](../README.md) lines 3-17 define StateLock as a memory sidecar and state it does not route model calls.
+- [`docs/architecture-tracks.md`](../docs/architecture-tracks.md) lines 14-34 divide responsibilities between Core and Observability.
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py) lines 16-151 show conversations, spans, working contexts, telemetry snapshots, memory entries, governance events, and pipeline logs already modeled.
+- [`examples/openclaw-tooling/AUTOMATION_CONTRACT.md`](../examples/openclaw-tooling/AUTOMATION_CONTRACT.md) lines 5-30 and 42-79 show current adapter-style integration.
+
+## Why Experience Is Different From Memory
+
+Plain memory answers “what should be remembered?”
+
+Experience answers “what worked, what failed, and what should influence future behavior?”
+
+That distinction matters because the repo already separates:
+
+- durable facts and retrievable blocks in Core
+- evaluation, run outcomes, traceability, and governance in Observability
+
+Repo-grounded evidence for an experience-like substrate already exists:
+
+- telemetry snapshots with metrics/actions in [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L95)
+- governance events in [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L132)
+- success/failure counters on memory entries in [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L127)
+- run-group and snapshot explainability in [`experimental/observability/app/api/telemetry.py`](../experimental/observability/app/api/telemetry.py#L90)
+- governance logs and rebuild actions in [`experimental/observability/app/api/governance.py`](../experimental/observability/app/api/governance.py#L16)
+
+That makes Experience a natural extension of **Observability memory + telemetry + governance**, rather than a new Core concern.
+
+## Proposed Extended Cognitive Loop
+
+Current repo-aligned loop:
+
+```text
+Conversation
+-> Observation
+-> Distillation
+-> Memory
+-> Context
+-> Reasoning
+```
+
+Proposed extended loop:
+
+```text
+Conversation
+-> Observation
+-> Distillation
+-> Memory
+-> Experience
+-> Context
+-> Reasoning
+-> Outcome
+-> Experience
+```
+
+Repo-aligned interpretation:
+
+- **Conversation**: turns, spans, threads, imported bundles
+- **Observation**: evidence extraction and thread assignment
+- **Distillation**: semantic/procedural memory proposals
+- **Memory**: durable Core blocks plus Observability memory entries
+- **Experience**: outcome-conditioned lessons derived from telemetry/governance/evals
+- **Context**: working-context builder output
+- **Reasoning**: still external to StateLock
+- **Outcome**: model/agent result plus measured run effects
+
+Evidence:
+
+- working context in [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py#L135)
+- telemetry in [`experimental/observability/app/services/telemetry_service.py`](../experimental/observability/app/services/telemetry_service.py#L63)
+- governance in [`experimental/observability/app/governance/actions.py`](../experimental/observability/app/governance/actions.py#L29)
+- distillation in [`experimental/observability/app/memory/distill.py`](../experimental/observability/app/memory/distill.py#L88)
+
+## The Layered Memory Model
+
+The layered model is useful, but each layer needs to be classified correctly.
+
+### Layer 0: Raw Archive
+
+Definition:
+
+- imported transcripts
+- conversation records
+- turns/spans
+- tool traces
+- execution logs
+
+Best owner:
+
+- **Observability**
+
+Repo status:
+
+- **partially represented**
+
+What exists:
+
+- conversations, turns, spans, pipeline logs, telemetry snapshots, governance events already exist in Observability models
+
+Evidence:
+
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py) lines 16-151
+
+What does not exist yet:
+
+- a dedicated raw filesystem archive store such as `archive/platform/conversation_id/raw.json`
+
+Command evidence:
+
+```text
+$ rg -n "archive/|raw.json|normalized.json" .
+[no relevant matches]
+```
+
+### Layer 1: Working Memory
+
+Definition:
+
+- recent conversation state
+- active task goals
+- temporary constraints
+
+Best owner:
+
+- **Observability / context builder**
+
+Repo status:
+
+- **already exists in substance**
+
+Evidence:
+
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L81) defines `WorkingContext`
+- [`experimental/observability/app/api/context.py`](../experimental/observability/app/api/context.py#L16) exposes working-context build/latest
+- [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py#L193) assembles procedures, key facts, recent turns, evidence spans, and tool outputs
+
+Important nuance:
+
+- This is better thought of as **active context state**, not durable memory.
+
+### Layer 2: Durable Semantic Memory
+
+Definition:
+
+- stable user preferences
+- project facts
+- recurring stable knowledge
+
+Best owner:
+
+- **Core**, with optional upstream generation from Observability distillation
+
+Repo status:
+
+- **already exists in general form**
+
+Evidence:
+
+- Core stores memory blocks in Chroma via [`app/core/database.py`](../app/core/database.py#L10)
+- Core CRUD/query APIs via [`app/routers/memories.py`](../app/routers/memories.py#L29)
+- Core examples already store preference/fact-shaped memories, e.g. [`examples/agent-memory-loop/README.md`](../examples/agent-memory-loop/README.md#L100)
+
+Nuance:
+
+- Core does not currently type these blocks as “semantic” internally.
+- So the layer is conceptually right, but the semantic labeling is mostly external/conceptual today.
+
+### Layer 3: Episodic Memory
+
+Definition:
+
+- notable prior events
+- decisions
+- solved incidents
+- bounded “episodes”
+
+Best owner:
+
+- **Observability first**
+
+Repo status:
+
+- **partially represented**
+
+Evidence:
+
+- `MemoryEntryOut.memory_type` already includes `episodic` in [`experimental/observability/app/schemas/models.py`](../experimental/observability/app/schemas/models.py#L125)
+- Observability MVP schema also models `memory_type: enum[episodic, semantic, procedural]` in [`experimental/observability/statelock-v2-mvp.yaml`](../experimental/observability/statelock-v2-mvp.yaml#L144)
+
+Nuance:
+
+- Current distillation implementation in [`experimental/observability/app/memory/distill.py`](../experimental/observability/app/memory/distill.py#L106) generates `semantic` and `procedural`, not `episodic`.
+- So episodic memory should remain a separate layer conceptually, but it is **not yet fully implemented**.
+
+### Layer 4: Procedural / Experience Memory
+
+Definition:
+
+- strategies that worked
+- failure patterns
+- workflow preferences
+- context heuristics
+- tool reliability patterns
+
+Best owner:
+
+- **Observability**
+
+Repo status:
+
+- **emerging / partially represented**
+
+Evidence:
+
+- Observability already stores `procedural` memory entries in [`experimental/observability/app/memory/distill.py`](../experimental/observability/app/memory/distill.py#L129)
+- The working-context builder explicitly selects procedural memory first in [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py#L40)
+- Memory entries already have evaluation fields `success_count`, `failure_count`, and `last_applied_at` in [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L127)
+- The design spec explicitly includes procedural entries with applicability, steps, and failure modes in [`experimental/observability/statelock-v2-mvp.yaml`](../experimental/observability/statelock-v2-mvp.yaml#L314)
+
+Recommendation:
+
+- Use **procedural / experience memory** as the repo-aligned term.
+- “Experience layer” is good as a conceptual umbrella.
+- “Experience memory” alone is slightly vague compared with the already-modeled `procedural` category.
+
+### Layer 5: Policy / Identity Layer
+
+Definition:
+
+- explicit user instructions
+- trust boundaries
+- architecture constraints
+- durable policy rules
+
+Best owner:
+
+- **constraints/configuration/policy layer**, not generic memory
+
+Repo status:
+
+- **partially represented, but not as a formal memory layer**
+
+Evidence:
+
+- deterministic save policy rules in [`app/services/automation_policy.py`](../app/services/automation_policy.py#L9)
+- OpenClaw-side save defaults in [`examples/openclaw-tooling/AUTOMATION_CONTRACT.md`](../examples/openclaw-tooling/AUTOMATION_CONTRACT.md#L92)
+- working-context guardrails are explicitly added in the Observability design spec in [`experimental/observability/statelock-v2-mvp.yaml`](../experimental/observability/statelock-v2-mvp.yaml#L193)
+
+Recommendation:
+
+- Rename this from **“Policy / Identity Memory”** to **“Policy / Constraints Layer.”**
+- It behaves more like configuration, rules, and guardrails than like ordinary retrievable memory.
+
+## Most Repo-Aligned Terminology
+
+Recommended naming adjustments:
+
+### Experience Layer
+
+Recommended phrase:
+
+- **Experience / Procedural Layer**
+
+Reason:
+
+- “experience” captures the product vision
+- “procedural” matches current repo schema and working-context builder behavior
+
+### Episodic Memory
+
+Recommendation:
+
+- keep **episodic** separate from semantic memory
+
+Reason:
+
+- the schema already distinguishes it conceptually
+- episodes and generalized facts serve different retrieval and promotion purposes
+
+### Policy / Identity Layer
+
+Recommendation:
+
+- rename to **Policy / Constraints Layer**
+
+Reason:
+
+- this repo currently treats policy more as rules/guardrails/config than as a normal memory family
+
+## Why StateLock Should Not Let the Current Conversation LLM Be the Sole Memory Authority
+
+The currently bound conversation LLM can help propose interpretations, but it should not be the sole authority for routing or promotion.
+
+Why:
+
+1. The runtime LLM is optimized for answering the current prompt, not for long-horizon storage decisions.
+2. The repo already uses deterministic and inspectable logic in key places:
+   - save triggers in [`app/services/automation_policy.py`](../app/services/automation_policy.py#L31)
+   - working-context assembly in [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py#L135)
+   - telemetry metrics in [`experimental/observability/app/services/telemetry_service.py`](../experimental/observability/app/services/telemetry_service.py#L45)
+   - governance remediation in [`experimental/observability/app/governance/actions.py`](../experimental/observability/app/governance/actions.py#L47)
+3. Provenance and traceability matter. A memory decision should be auditable against turns, spans, telemetry, and policies.
+
+So the correct architectural principle is:
+
+- **LLMs may propose memory candidates**
+- **StateLock should decide promotion/routing through a hybrid, provenance-aware pipeline**
+
+## Recommended Hybrid Decision Pipeline
+
+The repo-aligned decision pipeline is:
+
+1. **Deterministic rules**
+   - obvious triggers, bans, trust boundaries, explicit commands, policy rules
+   - existing precedent: save trigger patterns in [`app/services/automation_policy.py`](../app/services/automation_policy.py#L9)
+2. **Cheap classifier / heuristic stage**
+   - low-cost scoring for semantic vs episodic vs procedural tendency
+   - current precedent: thread inference, span scoring, recency/trust heuristics in [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py#L58)
+3. **Stronger distillation pass**
+   - higher-cost structured extraction and contradiction/redundancy checks
+   - current precedent: distillation critic pass described in [`experimental/observability/statelock-v2-mvp.yaml`](../experimental/observability/statelock-v2-mvp.yaml#L330)
+4. **Optional human confirmation for major promotions**
+   - use for irreversible or high-impact promotions such as durable architectural policies, user identity changes, or cross-project workflow canon
+
+This preserves safety and auditability without blocking normal operation.
+
+## How Routing and Promotion Decisions Should Work
+
+A repo-aligned rule of thumb:
+
+- keep raw interaction artifacts in Observability
+- keep active context in working-context state
+- promote stable generalized facts to Core when confidence and usefulness are high
+- keep strategy/outcome-conditioned lessons in Observability’s procedural/experience layer until proven durable
+- treat policy and trust constraints as explicit rules, not casual LLM-authored memory
+
+### Suggested promotion logic
+
+- **Layer 0 -> Layer 1**: automatic, local to the run
+- **Layer 1 -> Layer 3/4**: distillation and telemetry-informed extraction
+- **Layer 3/4 -> Layer 2**: only after stronger confidence/provenance thresholds
+- **Policy / Constraints**: deterministic or explicit confirmation path
+
+## How This Maps to Core vs Observability
+
+| Layer | Best owner | Repo status |
+|---|---|---|
+| Raw Archive | Observability | partial / future |
+| Working Memory | Observability | current |
+| Durable Semantic Memory | Core | current in generic form |
+| Episodic Memory | Observability first | partial / future |
+| Procedural / Experience Memory | Observability | emerging |
+| Policy / Constraints | docs/config/runtime rules | partial / future formalization |
+
+This preserves the Core vs Observability split and stays consistent with:
+
+- [`docs/architecture-tracks.md`](../docs/architecture-tracks.md)
+- [`docs/architecture-continuity-layer.md`](../docs/architecture-continuity-layer.md)
+- [`docs/statelock-cognitive-architecture.md`](../docs/statelock-cognitive-architecture.md)
+
+## What Is Current, Emerging, or Future
+
+### Implemented now
+
+- Core memory sidecar runtime
+- Core snapshots and insights
+- Observability conversations, spans, working context, telemetry, governance
+- Observability semantic/procedural distillation
+- adapter-style OpenClaw integration
+
+### Emerging
+
+- experience-like evaluation signals on memory entries
+- telemetry-driven refinement
+- procedural memory as reusable strategy layer
+
+### Future
+
+- explicit raw archive store
+- formal episodic-memory promotion path
+- explicit projection from Observability memory into Core memory blocks
+- richer policy/constraints layer
+- human-in-the-loop confirmation for major promotions
+
+## Why This Architecture Is Strong
+
+This framing is strong because it avoids a common failure mode: treating all memory as one undifferentiated bucket.
+
+Instead, it lets StateLock:
+
+- store durable facts in Core
+- reason about context and outcomes in Observability
+- keep promotion decisions inspectable
+- preserve provenance
+- learn from outcomes without collapsing into a model-router architecture
+
+That is consistent with the repo’s existing structure and gives a practical path forward.
+
+## Cross-Reference
+
+For the subsystem that decides how artifacts move between these layers, see:
+
+- [`docs/architecture-promotion-engine.md`](../docs/architecture-promotion-engine.md)
+- [`docs/architecture-promotion-schemas.md`](./architecture-promotion-schemas.md)
+- [`docs/architecture-memory-policy-profiles.md`](./architecture-memory-policy-profiles.md)

--- a/docs/architecture-promotion-engine.md
+++ b/docs/architecture-promotion-engine.md
@@ -1,0 +1,471 @@
+# StateLock Promotion Engine
+
+## Executive Summary
+
+The **Promotion Engine** concept is sound and fits the current repository, as long as it is placed primarily in the **Observability Track** and not treated as a Core runtime rewrite.
+
+Repo-aligned interpretation:
+
+- **Observability** should own artifact capture, provenance, classification, scoring, candidate records, experience extraction, and promotion logs.
+- **Core** should remain the stable destination for only the narrowest promoted subset: durable semantic memory blocks that are worth persisting in the canonical sidecar runtime.
+
+This matches the existing split:
+
+- Core = durable memory sidecar
+- Observability = conversation, context, telemetry, governance, distillation, and traceability
+
+Evidence:
+
+- [`docs/architecture-tracks.md`](../docs/architecture-tracks.md) lines 14-34 define the Core vs Observability responsibility split.
+- [`README.md`](../README.md) lines 3-17 define StateLock as a memory sidecar that does not route model calls.
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py) lines 16-151 already model the artifact types and outcome signals a Promotion Engine would need.
+- [`docs/architecture-memory-stratification.md`](../docs/architecture-memory-stratification.md) already places raw/working/episodic/procedural layers primarily under Observability.
+
+For the schema contract between Observability promotion records and Core memory blocks, see:
+
+- [`docs/architecture-promotion-schemas.md`](./architecture-promotion-schemas.md)
+
+For profile-driven budget and aggressiveness presets that shape promotion behavior, see:
+
+- [`docs/architecture-memory-policy-profiles.md`](./architecture-memory-policy-profiles.md)
+
+## What the Promotion Engine Is
+
+The Promotion Engine is the subsystem that decides how captured artifacts move through the stratified memory system.
+
+It decides whether an artifact remains:
+
+- archive-only
+- working-memory-only
+- candidate memory
+- durable semantic memory
+- episodic memory
+- procedural / experience memory
+- policy / constraints record
+
+Core principle:
+
+**Capture broadly. Promote narrowly.**
+
+That principle is already consistent with the repo’s current behavior:
+
+- Observability captures rich conversation/run structure.
+- Core stores only a simpler durable memory representation.
+
+## Why It Is Necessary
+
+Without a Promotion Engine, StateLock risks collapsing into one of two bad modes:
+
+1. **Everything becomes memory**
+   - low-trust or temporary artifacts pollute durable retrieval
+2. **Nothing becomes memory**
+   - continuity remains trapped in transient traces and never becomes reusable
+
+The repo already hints at the right balance:
+
+- Core uses narrow memory-save semantics and policy helpers in [`app/services/automation_policy.py`](../app/services/automation_policy.py#L31)
+- Observability already models distillation, telemetry, governance, provenance, and evaluation-like counters in:
+  - [`experimental/observability/app/memory/distill.py`](../experimental/observability/app/memory/distill.py#L88)
+  - [`experimental/observability/app/services/telemetry_service.py`](../experimental/observability/app/services/telemetry_service.py#L63)
+  - [`experimental/observability/app/governance/actions.py`](../experimental/observability/app/governance/actions.py#L29)
+  - [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L112)
+
+The Promotion Engine is the missing conceptual layer that ties those existing pieces together.
+
+## Recommended Terminology
+
+Recommended primary term:
+
+- **Promotion Engine**
+
+Recommended secondary phrase:
+
+- **memory promotion pipeline**
+
+Why:
+
+- “Promotion Engine” matches the state-transition nature of the system.
+- “memory promotion pipeline” is a useful descriptive alias for docs and design discussions.
+
+Less preferred:
+
+- **routing engine**
+  - too broad; could be confused with model routing, which StateLock does not own
+- **memory governor**
+  - suggests primarily restriction/policing rather than classification and advancement
+
+## Promotion Pipeline
+
+Recommended pipeline:
+
+1. **Artifact normalization**
+2. **Artifact classification**
+3. **Artifact scoring**
+4. **Rule evaluation**
+5. **Promotion decision / state transition**
+6. **Reinforcement / deprecation / retirement over time**
+
+### 1. Artifact normalization
+
+Purpose:
+
+- turn conversation events, tool outputs, imported bundles, and observed outcomes into a common internal artifact shape
+
+Likely owner:
+
+- Observability
+
+Existing grounding:
+
+- conversation import/export bundle machinery in [`experimental/observability/app/services/export_import.py`](../experimental/observability/app/services/export_import.py#L71)
+- spans, turns, working contexts, and telemetry snapshots in [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L31)
+
+### 2. Artifact classification
+
+Purpose:
+
+- decide whether an artifact is better treated as semantic, episodic, procedural/experience, policy/constraints, or archive-only
+
+Existing grounding:
+
+- `MemoryEntryOut.memory_type` already distinguishes `episodic`, `semantic`, and `procedural` in [`experimental/observability/app/schemas/models.py`](../experimental/observability/app/schemas/models.py#L125)
+- current distillation already creates `semantic` and `procedural` entries in [`experimental/observability/app/memory/distill.py`](../experimental/observability/app/memory/distill.py#L106)
+
+### 3. Artifact scoring
+
+Purpose:
+
+- estimate whether the artifact deserves promotion, delay, aggregation, or rejection
+
+Existing grounding:
+
+- Observability already scores spans and telemetry influence with deterministic logic in:
+  - [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py#L58)
+  - [`experimental/observability/app/services/telemetry_service.py`](../experimental/observability/app/services/telemetry_service.py#L45)
+
+### 4. Rule evaluation
+
+Purpose:
+
+- apply deterministic constraints, safety boundaries, explicit user instructions, and trust/policy rules
+
+Existing grounding:
+
+- Core save-policy rules in [`app/services/automation_policy.py`](../app/services/automation_policy.py#L9)
+- governance actions and quarantine behavior in [`experimental/observability/app/governance/actions.py`](../experimental/observability/app/governance/actions.py#L47)
+
+### 5. Promotion decision / state transition
+
+Purpose:
+
+- move artifacts into explicit lifecycle states rather than treating promotion as a hidden side effect
+
+This is mostly conceptual today.
+
+### 6. Reinforcement / deprecation / retirement
+
+Purpose:
+
+- allow memory to strengthen, weaken, or age out based on repeated success, contradiction, obsolescence, or policy risk
+
+Existing grounding:
+
+- `success_count`, `failure_count`, `last_applied_at` in [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L127)
+- `status` values `active`, `deprecated`, `quarantined` in [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L124)
+- contradiction and deprecation behavior in [`experimental/observability/app/memory/distill.py`](../experimental/observability/app/memory/distill.py#L129)
+
+## Scoring Model
+
+Suggested scoring axes:
+
+- durability
+- generality
+- specificity
+- actionability
+- confidence
+- repetition
+- user-explicitness
+- correction-signal
+- policy-risk
+- retrieval-value
+
+Repo alignment:
+
+- These should be treated as a **conceptual scoring framework**, not current implemented fields.
+- The repo currently has pieces of this spread across telemetry metrics, trust scores, memory strength, and save heuristics.
+
+Examples of existing nearby signals:
+
+- trust and recency in spans via [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py#L58)
+- alarms and off-thread coupling in [`experimental/observability/app/services/telemetry_service.py`](../experimental/observability/app/services/telemetry_service.py#L45)
+- explicit memory-save triggers in [`app/services/automation_policy.py`](../app/services/automation_policy.py#L9)
+- success/failure counters in [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L127)
+
+Recommended interpretation:
+
+- **implemented now**: trust, recency, alarms, memory strength, success/failure counters, save-trigger heuristics
+- **future**: unified promotion-scoring model that combines them
+
+## Promotion State Machine
+
+Suggested lifecycle states:
+
+- `captured`
+- `candidate`
+- `promoted`
+- `reinforced`
+- `deprecated`
+- `retired`
+
+Repo alignment:
+
+- `captured`, `candidate`, `promoted`, `reinforced`, and `retired` are **conceptual**
+- `deprecated` has a strong precedent already
+- `quarantined` already exists and should likely remain alongside this state machine as a safety-oriented status
+
+Evidence:
+
+- existing memory `status` values include `active`, `deprecated`, `quarantined` in [`experimental/observability/app/schemas/models.py`](../experimental/observability/app/schemas/models.py#L125)
+- distillation already deprecates outdated procedural memory in [`experimental/observability/app/memory/distill.py`](../experimental/observability/app/memory/distill.py#L134)
+- governance already quarantines spans in [`experimental/observability/app/governance/actions.py`](../experimental/observability/app/governance/actions.py#L47)
+
+Suggested repo-aligned state model:
+
+```text
+captured -> candidate -> promoted -> reinforced
+                           |            |
+                           v            v
+                      deprecated    deprecated
+                           |
+                           v
+                        retired
+
+quarantined = orthogonal safety status, not pure lifecycle state
+```
+
+## Decision Modes
+
+Recommended decision modes:
+
+- **immediate promotion**
+- **delayed promotion**
+- **aggregated promotion**
+- **human-gated promotion**
+
+### Immediate promotion
+
+Use when:
+
+- explicit user instruction
+- explicit policy statement
+- high-confidence stable semantic fact with low policy risk
+
+Current precedent:
+
+- explicit commands and rule triggers in [`app/services/automation_policy.py`](../app/services/automation_policy.py#L31)
+
+### Delayed promotion
+
+Use when:
+
+- artifact may matter, but needs more context or repeated confirmation
+
+Good fit for:
+
+- episodic memories
+- uncertain semantic claims
+
+### Aggregated promotion
+
+Use when:
+
+- one artifact alone is weak, but repeated observations strongly imply a stable lesson
+
+Good fit for:
+
+- workflow preferences
+- tool reliability patterns
+- recurring strategy success/failure
+
+### Human-gated promotion
+
+Use when:
+
+- policy risk is high
+- the artifact changes identity, durable constraints, or architecture canon
+
+Good fit for:
+
+- project architectural rules
+- user identity updates
+- cross-project workflow canon
+
+## Anti-Poisoning Protections
+
+The Promotion Engine should explicitly defend against memory poisoning, self-reinforcing hallucination, and accidental policy drift.
+
+Recommended protections:
+
+1. **Provenance requirement**
+   - promoted artifacts must point back to source turns/spans/import records
+2. **Contradiction-aware promotion**
+   - contradiction with existing durable memory lowers promotion confidence
+3. **Quarantine path**
+   - suspicious artifacts should be held or quarantined instead of promoted
+4. **Policy-risk gating**
+   - policy/constraints-like artifacts should require deterministic rules or confirmation
+5. **No sole LLM authority**
+   - the active conversation model can propose candidates, but not unilaterally promote them
+
+Repo grounding:
+
+- provenance fields exist on spans and memory entries in [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L61) and [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L125)
+- contradiction links already exist on spans in [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L63)
+- quarantine already exists in governance flows in [`experimental/observability/app/governance/actions.py`](../experimental/observability/app/governance/actions.py#L47)
+
+## Contradiction, Reinforcement, Deprecation, and Retirement
+
+### Contradiction
+
+Conceptual rule:
+
+- contradiction does not immediately delete memory
+- it should reduce confidence or route an artifact to candidate/quarantine review
+
+Repo evidence:
+
+- contradiction links exist on spans in [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L63)
+- distillation already marks outdated procedural entries as deprecated in [`experimental/observability/app/memory/distill.py`](../experimental/observability/app/memory/distill.py#L134)
+
+### Reinforcement
+
+Conceptual rule:
+
+- repeated successful reuse should strengthen promotion confidence and retrieval priority
+
+Repo evidence:
+
+- `success_count` and `last_applied_at` already exist on memory entries in [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L127)
+
+### Deprecation
+
+Conceptual rule:
+
+- outdated but historically meaningful artifacts should become less active before full retirement
+
+Repo evidence:
+
+- `deprecated` already exists as a memory status in [`experimental/observability/app/schemas/models.py`](../experimental/observability/app/schemas/models.py#L125)
+
+### Retirement
+
+Conceptual rule:
+
+- stale, contradicted, or low-value artifacts can eventually be retired from active retrieval while still preserving provenance
+
+Repo status:
+
+- future concept; not explicitly implemented today
+
+## How the Engine Maps to Core vs Observability
+
+### Observability owns
+
+- artifact capture
+- normalization
+- provenance
+- classification
+- scoring
+- candidate records
+- telemetry-informed experience extraction
+- promotion logs
+- deprecation and reinforcement signals
+
+This is the natural home because Observability already contains:
+
+- turns/spans/threads
+- working context
+- telemetry
+- governance
+- distillation
+- memory-entry eval metadata
+
+### Core owns
+
+- the narrow final destination for promoted durable semantic memory blocks
+- stable retrieval and persistence once promotion is already decided
+
+This preserves:
+
+- Core as the stable memory sidecar
+- Observability as the experimental continuity/promotion engine
+
+## Example Artifact Flow
+
+Example artifact:
+
+> “Core should remain the stable memory sidecar, Observability owns conversation-centric capabilities.”
+
+Possible routing path:
+
+1. **Raw archive**
+   - captured as conversation turns/imported discussion artifacts in Observability
+2. **Working memory**
+   - appears in the current working context while architectural discussion is active
+3. **Episodic memory**
+   - stored as a notable architecture decision episode tied to a specific discussion/run
+4. **Durable semantic memory**
+   - promoted only if repeated and stable enough to become a durable repo fact or project principle
+5. **Policy / constraints**
+   - if it becomes a project-wide architectural constraint, it may be elevated into policy/constraints documentation rather than ordinary memory
+6. **Procedural / experience lesson**
+   - if repeated work shows that keeping Core stable and putting conversation features in Observability consistently reduces churn, that becomes an experience/procedural lesson
+
+Why this example matters:
+
+- the same artifact may validly exist in multiple layers for different reasons
+- promotion is not a single yes/no decision
+- repo-aligned architecture needs both provenance and restraint
+
+## What Is Current vs Future
+
+### Implemented now
+
+- Core durable memory runtime
+- Core save heuristics and session logic
+- Observability turns/spans/working context
+- Observability telemetry/governance
+- Observability semantic/procedural distillation
+- existing `active` / `deprecated` / `quarantined` style status controls
+
+### Emerging
+
+- procedural memory as a proto-experience layer
+- success/failure counters as reinforcement signals
+- governance-driven adaptation and context rebuilding
+
+### Future
+
+- explicit Promotion Engine subsystem
+- unified promotion scoring model
+- explicit candidate/promotion state machine
+- durable projection path from Observability memory into Core blocks
+- retirement lifecycle
+- human-gated promotion workflows
+
+## Recommended Phased Implementation Sequence
+
+1. **Document the Promotion Engine**
+   - terminology, states, scoring, ownership boundaries
+2. **Define normalized artifact and provenance interfaces**
+   - stay in Observability
+3. **Add candidate/promotion metadata to Observability models**
+   - only after the design stabilizes
+4. **Wire reinforcement/deprecation signals**
+   - use existing telemetry/governance/eval counters
+5. **Introduce explicit projection rules into Core**
+   - only for durable semantic memory
+6. **Add human-gated paths for policy/high-risk promotion**
+   - later phase
+
+This sequence keeps changes incremental and preserves the current Core vs Observability split.

--- a/docs/architecture-promotion-schemas.md
+++ b/docs/architecture-promotion-schemas.md
@@ -1,0 +1,616 @@
+# StateLock Promotion Schemas and Projection Boundary
+
+## 1. Executive Summary
+
+This schema pass is both **sound** and **necessary**.
+
+The repo’s architecture docs now align on the big picture:
+
+- **Core Track** is the stable memory sidecar runtime.
+- **Observability Track** owns conversation-centric continuity, traceability, governance, and distillation.
+- **Promotion** should happen primarily in Observability, not in Core.
+
+What is still underspecified is the exact contract between:
+
+- captured artifacts,
+- promotion evidence,
+- promotion decisions,
+- promotion lifecycle state,
+- and the narrow projection boundary into Core durable semantic memory blocks.
+
+Repo-aligned conclusion:
+
+- **Observability** should own the rich promotion objects.
+- **Core** should receive only a **reduced semantic projection** in the shape of a normal Core memory block.
+- The canonical cross-track record should be a **ProjectionRecord** stored on the Observability side and pointing to the Core memory block that was created or updated.
+
+Evidence:
+
+- [`README.md`](../README.md#L3) defines StateLock as a memory sidecar and states it does not route model calls.
+- [`docs/architecture-tracks.md`](./architecture-tracks.md#L14) defines Core as the canonical runtime and Observability as the subsystem for traceability and governance.
+- [`app/models/schemas.py`](../app/models/schemas.py#L8) shows Core accepts simple memory-block payloads rather than rich provenance-heavy records.
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L16) already contains conversations, turns, spans, working contexts, telemetry snapshots, memory entries, governance events, and pipeline logs.
+
+## 2. Why Schema Precision Is the Next Bottleneck
+
+The architecture is conceptually strong, but implementation planning will stall unless the promotion boundary is explicit.
+
+Without schema precision, several failure modes become likely:
+
+- Core receives overly rich or unstable objects and stops being “narrow and boring”.
+- Observability and Core duplicate state without a clear source of truth.
+- provenance disappears at the moment of projection.
+- contradiction, supersession, and review states are modeled inconsistently.
+
+The repo already shows a clear asymmetry that should be preserved:
+
+- Core memory objects are intentionally simple: content, name, session, tags, timestamps, deterministic IDs via `external_id` ([`app/models/schemas.py`](../app/models/schemas.py#L50), [`app/services/memory_service.py`](../app/services/memory_service.py#L128)).
+- Observability objects are intentionally richer and already carry run- and trace-level evidence, contradictions, quarantine fields, counters, and governance logs ([`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L46), [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L95), [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L112)).
+
+That makes schema design at the **promotion boundary** the next bottleneck.
+
+## 3. Current Repo Reality and Existing Relevant Models
+
+### Core models that shape the boundary
+
+Core already has a stable durable-memory contract:
+
+- `MemoryCreate`
+- `MemoryUpsert`
+- `MemoryResponse`
+- `SessionSnapshotResponse`
+
+Evidence:
+
+- [`app/models/schemas.py`](../app/models/schemas.py#L46) defines the Core write payloads.
+- [`app/services/memory_service.py`](../app/services/memory_service.py#L98) stores only `content`, `name`, `session_id`, `tags_json`, timestamps, and optional `external_id`.
+
+Important implication:
+
+Core has **no current schema slot** for:
+
+- source conversations,
+- turn/span refs,
+- evidence sets,
+- decision modes,
+- review states,
+- contradiction refs,
+- promotion scores.
+
+Those must remain Observability-owned.
+
+### Observability models that already approximate promotion data
+
+Observability already has several adjacent concepts:
+
+- `Span.provenance_json`
+- `Span.contradictions_json`
+- `Span.quarantined_until`
+- `TelemetrySnapshot.run_group_id`
+- `TelemetrySnapshot.metrics_json`
+- `TelemetrySnapshot.actions_taken_json`
+- `MemoryEntry.memory_type`
+- `MemoryEntry.status`
+- `MemoryEntry.source_turn_ids_json`
+- `MemoryEntry.source_span_ids_json`
+- `MemoryEntry.success_count`
+- `MemoryEntry.failure_count`
+
+Evidence:
+
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L46)
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L95)
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L112)
+- [`experimental/observability/app/schemas/models.py`](../experimental/observability/app/schemas/models.py#L125) exposes `memory_type` as `episodic | semantic | procedural`.
+
+Important implication:
+
+The repo already has the building blocks for:
+
+- artifact provenance
+- contradiction handling
+- quarantine/safety handling
+- semantic vs procedural vs episodic classification
+- reinforcement/deprecation signals
+
+What it does **not** yet have is a single explicit promotion schema layer tying them together.
+
+### Existing adapter contract
+
+OpenClaw-style integrations already consume a narrow memory contract rather than a gateway API.
+
+Evidence:
+
+- [`examples/openclaw-tooling/AUTOMATION_CONTRACT.md`](../examples/openclaw-tooling/AUTOMATION_CONTRACT.md#L5) defines `memory.query`.
+- [`examples/openclaw-tooling/AUTOMATION_CONTRACT.md`](../examples/openclaw-tooling/AUTOMATION_CONTRACT.md#L42) defines `memory.save`.
+
+Important implication:
+
+The promotion boundary should eventually expose a **narrow adapter contract**, not make external agents speak full internal promotion schemas.
+
+## 4. PromotionArtifact
+
+### Purpose
+
+`PromotionArtifact` is the normalized unit entering the promotion pipeline.
+
+It should live in **Observability**.
+
+It is not a Core object.
+
+### Recommended shape
+
+```yaml
+PromotionArtifact:
+  artifact_id: string
+  artifact_type: string
+  source_type: string
+  source_platform: string | null
+  content: string
+  summary: string | null
+  conversation_id: string | null
+  turn_ids: string[]
+  span_ids: string[]
+  run_group_id: string | null
+  session_id: string | null
+  origin_actor: string | null
+  created_at: datetime
+  metadata: object
+  trust_signals: object
+  candidate_layers: string[]
+```
+
+### Field guidance
+
+- `artifact_id`: keep
+- `artifact_type`: keep
+- `source_type`: keep
+- `source_platform`: optional, useful for imports/adapters
+- `content`: keep
+- `summary`: optional, do not require in MVP
+- `conversation_id`: keep when applicable
+- `turn_ids`: keep
+- `span_ids`: keep
+- `run_id`: **rename to `run_group_id`** to match existing Observability terminology ([`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L101))
+- `session_id`: keep, because external adapters and Core already use it ([`app/models/schemas.py`](../app/models/schemas.py#L20))
+- `actor`: **rename to `origin_actor`** or `speaker` for clarity; the repo already uses `speaker` on turns ([`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L37))
+- `metadata`: keep, but narrow
+- `trust_signals`: keep; this aligns with existing trust and alarm concepts
+- `candidate_layers`: useful but **future/derived**; it does not need to be stored in the first version
+
+### Repo-aligned interpretation
+
+Implemented now:
+
+- parts of this object are already spread across `Turn`, `Span`, `WorkingContext`, `TelemetrySnapshot`, and `MemoryEntry`
+
+Conceptual/future:
+
+- one normalized `PromotionArtifact` record unifying them
+
+## 5. PromotionEvidence
+
+### Purpose
+
+`PromotionEvidence` explains **why** an artifact deserves promotion or non-promotion.
+
+It should also remain **Observability-owned**.
+
+### Recommended shape
+
+```yaml
+PromotionEvidence:
+  evidence_id: string
+  artifact_id: string
+  evidence_type: string
+  source_refs:
+    conversation_id: string | null
+    turn_ids: string[]
+    span_ids: string[]
+    snapshot_ids: string[]
+    governance_event_ids: string[]
+  repetition_count: integer
+  confidence: float | null
+  explicitness: float | null
+  correction_signal: float | null
+  contradiction_refs: string[]
+  notes: string | null
+  signals: object
+```
+
+### Field guidance
+
+- `source_refs`: keep as structured refs, not opaque text
+- `repetition_count`: keep
+- `confidence`: keep
+- `explicitness`: keep
+- `correction_signal`: keep
+- `contradiction_refs`: keep
+- `notes`: optional only
+- `signals`: useful as an extension bucket for metrics not yet stabilized
+
+### Why this fits the repo
+
+This schema maps cleanly onto existing evidence sources:
+
+- `source_turn_ids_json` / `source_span_ids_json` on `MemoryEntry`
+- `metrics_json` / `actions_taken_json` on `TelemetrySnapshot`
+- `contradictions_json` and `provenance_json` on `Span`
+- governance logs on `GovernanceEvent`
+
+Evidence:
+
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L62)
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L108)
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L125)
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L132)
+
+## 6. PromotionDecision
+
+### Purpose
+
+`PromotionDecision` is the engine’s explicit routing/promotion outcome for an artifact.
+
+### Recommended shape
+
+```yaml
+PromotionDecision:
+  decision_id: string
+  artifact_id: string
+  target_layer: string
+  decision_outcome: string
+  confidence: float | null
+  reason_codes: string[]
+  evidence_ids: string[]
+  decided_by: string
+  decision_mode: string
+  requires_review: boolean
+  created_at: datetime
+```
+
+### Terminology guidance
+
+- `decision`: rename to **`decision_outcome`** for clarity
+- `decided_by`: keep, but allow values such as:
+  - `rule_engine`
+  - `heuristic_classifier`
+  - `llm_judge`
+  - `human_review`
+  - `hybrid`
+- `decision_mode`: keep, matching the promotion-engine doc:
+  - `immediate`
+  - `delayed`
+  - `aggregated`
+  - `human_gated`
+
+### Why it is necessary
+
+The repo currently has actions and heuristics, but not a durable decision record connecting:
+
+- artifact
+- evidence
+- target layer
+- mode
+- review requirement
+
+That gap should be closed in Observability before any projection to Core.
+
+## 7. PromotionStatus
+
+### Purpose
+
+`PromotionStatus` separates lifecycle from safety/handling state.
+
+That separation matters because the repo already treats quarantine as a special handling state, not normal progression.
+
+Evidence:
+
+- `Span.quarantined_until` exists independently of memory lifecycles in [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L64)
+- `MemoryEntry.status` already mixes lifecycle-like and safety-like terms (`active`, `deprecated`, `quarantined`) in [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py#L124)
+
+### Recommended model
+
+```yaml
+PromotionStatus:
+  lifecycle_state: enum[
+    captured,
+    candidate,
+    promoted,
+    reinforced,
+    deprecated,
+    retired
+  ]
+  safety_state: enum[
+    normal,
+    quarantined,
+    disputed,
+    superseded,
+    review_required
+  ]
+```
+
+### Recommendation
+
+Preserve the earlier design choice:
+
+- **`quarantined` should remain orthogonal to lifecycle**
+
+That keeps the model cleaner and avoids encoding safety as if it were just another maturity stage.
+
+## 8. ProjectionRecord
+
+### Purpose
+
+`ProjectionRecord` is the most important new schema.
+
+It should be the **canonical boundary object** between Observability and Core.
+
+### Recommended shape
+
+```yaml
+ProjectionRecord:
+  projection_id: string
+  source_artifact_id: string
+  source_decision_id: string
+  source_layer: string
+  projection_type: string
+  projection_status: string
+  projected_at: datetime | null
+  projected_by: string
+  destination_memory_block_id: string | null
+  destination_memory_external_id: string | null
+  projection_fidelity: enum[lossy, lossless]
+  projection_notes: string | null
+  supersedes_memory_block_id: string | null
+  provenance_refs:
+    conversation_id: string | null
+    turn_ids: string[]
+    span_ids: string[]
+    run_group_id: string | null
+    evidence_ids: string[]
+    decision_id: string
+  core_memory_payload:
+    content: string
+    name: string | null
+    session_id: string
+    tags: string[]
+    external_id: string
+```
+
+### Why this is the canonical boundary object
+
+The boundary should not be the full promoted artifact.
+
+It should not be raw trace records.
+
+It should be:
+
+1. a **Core-compatible semantic projection payload**, plus
+2. an **Observability-side trace record** proving where it came from and why it was promoted.
+
+That is exactly what `ProjectionRecord` captures.
+
+### Core payload guidance
+
+Core should receive only the reduced `core_memory_payload`, which is intentionally shaped like `MemoryUpsert`.
+
+Evidence:
+
+- [`app/models/schemas.py`](../app/models/schemas.py#L50) defines `MemoryUpsert` with `id`, `external_id`, `content`, `name`, `session_id`, and `tags`
+- [`app/services/memory_service.py`](../app/services/memory_service.py#L128) shows Core already supports deterministic `external_id`-driven upserts
+
+### Important naming recommendation
+
+`lossy_or_lossless` should be renamed to **`projection_fidelity`**.
+
+It is cleaner and easier to type as an enum.
+
+`provenance_bundle` should be replaced by **structured `provenance_refs`** in the first version.
+
+Opaque provenance blobs are harder to reason about and harder to query.
+
+## 9. Observability → Core Projection Boundary
+
+### Canonical answer
+
+The canonical boundary object should be:
+
+- **`ProjectionRecord` in Observability**
+
+And the actual payload sent to Core should be:
+
+- a **reduced semantic projection** compatible with `MemoryUpsert`
+
+### Therefore Core should receive
+
+Not this:
+
+- full promoted artifacts
+- full evidence graphs
+- run traces
+- raw telemetry snapshots
+- governance logs
+
+Instead, Core should receive only:
+
+- already-distilled stable semantic memory blocks
+- with deterministic IDs and simple retrieval metadata
+
+### Projection direction
+
+Projection should be:
+
+- **one-way operationally**
+- **traceable by provenance**
+- **reversible by supersession/deprecation**, not by full round-trip reconstruction
+
+That means:
+
+- Core is not the source of truth for promotion history.
+- Observability remains the source of truth for why a memory exists and whether it should still be considered valid.
+
+## 10. What Projects Into Core vs What Stays in Observability
+
+### Projects into Core
+
+- stable durable semantic memory
+- explicit user preferences that have cleared promotion thresholds
+- stable architecture/project facts
+- recurring workflow facts once abstracted into semantic form
+
+### Stays in Observability
+
+- raw archive/transcript material
+- working memory / active context state
+- telemetry snapshots
+- governance logs
+- contradiction sets
+- review queues
+- procedural / experience memory
+- most episodic memory
+
+### Episodic memory rule
+
+Episodic memory should **not** project directly into Core by default.
+
+If it projects at all, it should first be **transformed** into a durable semantic or policy-level conclusion.
+
+Example:
+
+- episode: “On 2026-03-06, the sessions page falsely showed `Load failed` due to a redirect loop and shared error state.”
+- semantic projection: “The Core memories collection route requires canonical trailing-slash handling through the proxy.”
+
+### Procedural / experience memory rule
+
+Procedural / experience memory should remain Observability-owned.
+
+Schema-level difference from durable semantic memory:
+
+- semantic memory answers **what is true / stable**
+- procedural / experience memory answers **what tends to work / fail**
+
+The latter is closer to telemetry- and outcome-conditioned heuristics than to durable fact memory.
+
+### Policy / constraints rule
+
+Policy / constraints items should generally **not** project into Core as ordinary memory.
+
+They should live in:
+
+- docs
+- config
+- explicit runtime constraints
+- governance/policy registries
+
+An exception may exist for user-authored explicit preferences that are intentionally modeled as durable semantic memory, but that should be a deliberate special case.
+
+## 11. Provenance Requirements
+
+Minimum provenance that must survive projection:
+
+- source artifact id
+- source decision id
+- source conversation id when present
+- source turn/span refs when present
+- source run group id when present
+- destination Core memory block id
+- destination deterministic external id
+- projection timestamp
+- supersession pointer when applicable
+
+Why:
+
+Without these, Core memory becomes detached from:
+
+- the conversation/run that produced it
+- the decision/evidence that justified promotion
+- later contradiction or retirement logic
+
+This is especially important because Core storage itself does not currently carry rich provenance fields.
+
+## 12. Contradiction / Supersession / Review Handling
+
+### Contradiction
+
+Contradiction should be modeled primarily in Observability, not in Core.
+
+Use:
+
+- contradiction refs in `PromotionEvidence`
+- `disputed` or `review_required` safety state in `PromotionStatus`
+
+Core should not need native contradiction machinery in the first version.
+
+### Supersession
+
+Supersession should be modeled through:
+
+- `supersedes_memory_block_id` on `ProjectionRecord`
+- `safety_state = superseded` on prior decision/projection records
+- optional deprecation of related Observability memory entries
+
+This preserves a clean chain without forcing Core to support lineage graphs.
+
+### Review handling
+
+Human approval should fit without overcomplicating v1:
+
+- `requires_review: boolean` on `PromotionDecision`
+- `safety_state = review_required` on `PromotionStatus`
+- optional `reviewed_by`, `reviewed_at`, `review_notes` can be deferred until actual UI/workflow design exists
+
+That keeps the first schema implementation-friendly.
+
+## 13. Minimal Viable Schema Set
+
+Recommended minimum schema set for the first implementation phase:
+
+1. `PromotionArtifact`
+2. `PromotionEvidence`
+3. `PromotionDecision`
+4. `ProjectionRecord`
+
+`PromotionStatus` can be implemented either:
+
+- as a small embedded subobject on artifact/decision records, or
+- as a separate table/model later if lifecycle transitions become complex
+
+Why this is enough:
+
+- artifact = what entered the pipeline
+- evidence = why promotion seems justified
+- decision = what the engine decided
+- projection = what crossed into Core
+
+That is the minimum needed for auditable promotion.
+
+## 14. Recommended Implementation Sequence
+
+1. **Document the schema boundary first**
+   - this document
+2. **Add Observability-side conceptual models**
+   - artifact, evidence, decision, projection
+3. **Keep Core unchanged initially**
+   - reuse `MemoryUpsert` payload shape
+4. **Add projection write path**
+   - Observability emits reduced semantic block into Core
+5. **Add reinforcement/deprecation hooks**
+   - driven by telemetry/governance outcomes
+6. **Only then consider richer review/supersession UI**
+
+This sequence keeps Core stable and pushes experimentation where the repo already expects it: Observability.
+
+## 15. Open Questions
+
+1. Should `PromotionArtifact` be a durable DB model or a normalized transient pipeline object first?
+2. Should `PromotionEvidence` be one record per source signal, or a compact aggregate per decision?
+3. What deterministic `external_id` strategy should be used for projected Core blocks?
+4. When an existing Core block is superseded, should Core memory content be updated in place or appended as a new block with lineage kept only in Observability?
+5. Should some high-confidence explicit user constraints bypass the normal semantic projection path and land in a separate policy registry instead of Core memory?
+
+## Cross-Reference
+
+- Promotion/routing behavior: [`docs/architecture-promotion-engine.md`](./architecture-promotion-engine.md)
+- Layering model: [`docs/architecture-memory-stratification.md`](./architecture-memory-stratification.md)
+- Relationship/provenance structure: [`docs/architecture-memory-graph.md`](./architecture-memory-graph.md)
+- Track ownership: [`docs/architecture-continuity-layer.md`](./architecture-continuity-layer.md)

--- a/docs/architecture-sanity-check.md
+++ b/docs/architecture-sanity-check.md
@@ -1,0 +1,577 @@
+# Architecture Sanity Check
+
+## 1. Executive Summary
+
+The proposed architecture is **directionally useful as a long-range product vision**, but it is **not accurate as the immediate architecture plan for this repo without revision**.
+
+The most important correction is structural:
+
+- **Core Track** is currently a memory sidecar runtime, not a model gateway.
+- **Observability Track** already owns most of the conversation-level concepts in the proposal: conversation import/export, working-context construction, telemetry, governance, and memory distillation.
+- **OpenClaw integration** is currently documented and implemented as an external tool/sidecar contract, not as first-class `/gateway/*` routes inside Core.
+- **Encrypted local storage / PQC** is not evidenced as current repo groundwork and should be treated as a future security design track, not part of the near-term MVP.
+
+Evidence:
+
+- [`docs/architecture-tracks.md`](../docs/architecture-tracks.md): “Core Track: canonical runtime for memory sidecar operations” and “Observability Track: subsystem for agent execution state, traceability, and governance.” See lines 3-6 and 14-34.
+- [`README.md`](../README.md): “StateLock handles memory persistence/retrieval. It does **not** route model calls.” See lines 3-17.
+- [`experimental/observability/README.md`](../experimental/observability/README.md): Observability already “builds bounded working context,” “computes telemetry,” and “distills long conversations into reusable memory entries.” See lines 13-20.
+
+Bottom line:
+
+- The proposal should be **revised** before implementation.
+- The safest path is to keep **Core stable**, keep new conversation-centric capabilities in **Observability**, and start any OpenClaw work as **examples/adapters first**, not as a new root gateway subsystem.
+
+## 2. Current Repo Reality
+
+### 2.1 Core Track today
+
+Core is a FastAPI memory sidecar with Chroma-backed storage and a narrow runtime role.
+
+Evidence:
+
+- [`README.md`](../README.md) lines 3-17:
+  > StateLock Engine is a self-hosted memory sidecar API … StateLock handles memory persistence/retrieval. It does not route model calls.
+- [`main.py`](../main.py) lines 20-27:
+  ```python
+  app = FastAPI(...)
+  app.include_router(memories.router, prefix=settings.API_PREFIX, tags=["Memories"])
+  app.include_router(insights.router, tags=["Insights"])
+  ```
+- [`app/core/config.py`](../app/core/config.py) lines 10-21:
+  ```python
+  API_PREFIX: str = "/memories"
+  AUTH_REQUIRED: bool = False
+  STATELOCK_API_KEY: str = ""
+  ```
+- [`app/core/database.py`](../app/core/database.py) lines 10-20:
+  ```python
+  cls._client = chromadb.PersistentClient(path=settings.CHROMA_DB_PATH)
+  cls._collection = client.get_or_create_collection(name="memory_blocks")
+  ```
+- [`app/services/memory_service.py`](../app/services/memory_service.py) lines 98-166 and 167-257 show add/upsert/query/hybrid query over memory blocks, not transcript ingestion or provenance archives.
+
+Core endpoints confirmed in repo:
+
+- [`app/routers/memories.py`](../app/routers/memories.py) lines 29-99
+- [`app/routers/insights.py`](../app/routers/insights.py) lines 14-39
+- [`main.py`](../main.py) lines 92-104
+
+These cover:
+
+- `POST /memories/`
+- `POST /memories/upsert`
+- `POST /memories/query`
+- `POST /memories/query-hybrid`
+- `GET /memories/`
+- session snapshot/restore
+- `/stats/overview`
+- `/sessions`
+- `/tags`
+- `/healthz`
+- `/readyz`
+
+### 2.2 Observability Track today
+
+Observability is already a substantial conversation-centric subsystem under `experimental/observability/`.
+
+Evidence:
+
+- [`docs/architecture-tracks.md`](../docs/architecture-tracks.md) lines 25-34 assigns Observability:
+  - conversations, turns, spans
+  - working context construction
+  - execution telemetry and explainability
+  - governance actions and auditability
+  - conversation export/import bundles
+- [`experimental/observability/app/main.py`](../experimental/observability/app/main.py) lines 42-55 mounts routers for:
+  - conversations
+  - turns
+  - segmentation
+  - context
+  - telemetry
+  - governance
+  - memory
+  - spans
+  - debug
+- [`experimental/observability/app/api/conversations.py`](../experimental/observability/app/api/conversations.py) lines 40-62 already implements:
+  - `POST /v2/conversations/import`
+  - `GET /v2/conversations/{conversation_id}/export`
+- [`experimental/observability/app/api/context.py`](../experimental/observability/app/api/context.py) lines 16-46 already implements:
+  - `POST /v2/conversations/{conversation_id}/working_context`
+  - `GET /v2/conversations/{conversation_id}/working_context/latest`
+- [`experimental/observability/app/api/memory.py`](../experimental/observability/app/api/memory.py) lines 16-45 already implements:
+  - `GET /v2/memory`
+  - `POST /v2/conversations/{conversation_id}/memory/distill`
+
+### 2.3 Current OpenClaw integration model
+
+OpenClaw is currently integrated in **sidecar/tool mode**, not via internal gateway routes.
+
+Evidence:
+
+- [`docs/run-with-local-first-stack.md`](../docs/run-with-local-first-stack.md) lines 36-43:
+  > Use a tool wrapper that calls StateLock:
+  > - `memory.save`
+  > - `memory.query`
+  > - `memory.clear_session`
+- [`docs/run-with-local-first-stack.md`](../docs/run-with-local-first-stack.md) lines 66-75 show the current flow:
+  1. Agent receives message
+  2. derive session id
+  3. call `memory.query`
+  4. build prompt
+  5. call LiteLLM
+  6. save facts with `memory.save`
+- [`examples/openclaw-tooling/README.md`](../examples/openclaw-tooling/README.md) lines 3-11 defines the tool surface:
+  - `memory.save`
+  - `memory.query`
+  - `memory.clear_session`
+
+### 2.4 Web UI role today
+
+The Next app is a **thin proxy UI**, not an orchestration or gateway layer.
+
+Evidence:
+
+- [`apps/web/README.md`](../apps/web/README.md) lines 1-4:
+  > Thin Next.js UI for the existing Core and Observability backends.
+- [`apps/web/README.md`](../apps/web/README.md) lines 18-20:
+  - `/api/core/*`
+  - `/api/obs/*`
+- [`apps/web/lib/proxy.ts`](../apps/web/lib/proxy.ts) lines 40-55 and 171-189 show env-pinned upstream proxying, not business logic ownership.
+
+## 3. Proposed Architecture vs Current Repo Matrix
+
+| Proposed subsystem | Repo status | Evidence | Notes |
+|---|---|---|---|
+| `app/importers/` historical chat importers | **Missing in root app** | `find app -maxdepth 2 -type d | sort` returns only `app/core`, `app/models`, `app/routers`, `app/services` | Import-like behavior exists only as conversation bundle import in Observability, not root Core importers. |
+| normalized conversation schema | **Partially exists** | [`experimental/observability/app/services/export_import.py`](../experimental/observability/app/services/export_import.py) lines 71-121 and 124-260 | Exists as Observability conversation bundle schema, not as a cross-platform chat-import schema for ChatGPT/Claude/Telegram/Discord. |
+| raw archive store of exact originals | **Missing** | `rg -n "archive/|Raw Archive Store|raw.json|normalized.json" .` returned no relevant hits | No repo evidence of filesystem raw transcript archive storage. |
+| provenance/audit/replay | **Partially exists** | [`docs/provenance/seed-migration-manifest.md`](../docs/provenance/seed-migration-manifest.md), [`experimental/observability/app/services/export_import.py`](../experimental/observability/app/services/export_import.py) | Provenance exists in limited forms, but not the proposed raw-archive-backed provenance tracker. |
+| memory distiller | **Exists in Observability, not Core** | [`experimental/observability/app/memory/distill.py`](../experimental/observability/app/memory/distill.py) lines 88-158 | The repo already has a distillation engine, but it belongs to Observability. |
+| distilled memory graph/vector DB | **Partially exists** | Core uses Chroma memory blocks in [`app/core/database.py`](../app/core/database.py); Observability stores `MemoryEntry` records in SQLite via [`experimental/observability/app/api/memory.py`](../experimental/observability/app/api/memory.py) | There is no explicit “memory graph” subsystem. Current storage is split across Core Chroma and Observability SQLite memory entries. |
+| context builder / rehydration engine | **Exists in Observability, not Core** | [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py) lines 135-200; [`experimental/observability/app/api/context.py`](../experimental/observability/app/api/context.py) lines 16-46 | Core examples emulate context assembly in scripts instead of owning a context-builder API. |
+| gateway adapter inside StateLock | **Conflicts with current design** | [`README.md`](../README.md) lines 11-17; [`docs/run-with-local-first-stack.md`](../docs/run-with-local-first-stack.md) lines 36-75 | Current architecture says StateLock is a memory sidecar and OpenClaw owns agent/model flow. |
+| `/gateway/context`, `/gateway/memory`, `/gateway/session/*` endpoints | **Missing and inconsistent with current API shape** | `rg -n "/gateway/|gateway" .` finds docs references but no runtime routes | Current API nouns are `/memories/*`, `/sessions`, `/tags`, and `/v2/conversations/*`; `/gateway/*` would be a new design surface. |
+| encrypted local storage model with PQC | **Speculative / missing** | `rg -n "ML-KEM|ML-DSA|SLH-DSA|AES-256-GCM|wrapped_key|signature.sig|app/security" .` returned no relevant hits | No current repo evidence for this as an implementation-ready subsystem. |
+| `app/security/` | **Missing** | `find app -maxdepth 2 -type d | sort` | No root security module exists. |
+
+Command output evidence for root app layout:
+
+```text
+$ find app -maxdepth 2 -type d | sort
+app
+app/core
+app/models
+app/routers
+app/services
+```
+
+Command output evidence for Observability app layout:
+
+```text
+$ find experimental/observability/app -maxdepth 2 -type d | sort
+experimental/observability/app
+experimental/observability/app/api
+experimental/observability/app/context_builder
+experimental/observability/app/db
+experimental/observability/app/governance
+experimental/observability/app/memory
+experimental/observability/app/pipelines
+experimental/observability/app/schemas
+experimental/observability/app/services
+experimental/observability/app/telemetry
+...
+```
+
+## 4. Confirmed Reusable Building Blocks
+
+These pieces are already real and reusable.
+
+### 4.1 Core reusable blocks
+
+- **Chroma-backed memory store** via [`app/core/database.py`](../app/core/database.py) lines 10-20
+- **Memory CRUD/query/upsert** via [`app/services/memory_service.py`](../app/services/memory_service.py)
+- **Session snapshot/restore** via [`app/services/memory_service.py`](../app/services/memory_service.py) lines 375-421 and [`app/routers/memories.py`](../app/routers/memories.py) lines 78-94
+- **Session-id conventions and save policy helpers** via [`app/services/automation_policy.py`](../app/services/automation_policy.py) lines 17-28 and 31-58
+- **Current schema contracts** via [`app/models/schemas.py`](../app/models/schemas.py)
+
+### 4.2 Observability reusable blocks
+
+- **Conversation export/import bundle** via [`experimental/observability/app/api/conversations.py`](../experimental/observability/app/api/conversations.py) and [`experimental/observability/app/services/export_import.py`](../experimental/observability/app/services/export_import.py)
+- **Working-context builder** via [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py)
+- **Memory distillation** via [`experimental/observability/app/memory/distill.py`](../experimental/observability/app/memory/distill.py)
+- **Turns/spans/telemetry/governance** via [`experimental/observability/app/main.py`](../experimental/observability/app/main.py) and subrouters
+
+### 4.3 Examples and integration assets
+
+- **OpenClaw tool-side integration** via [`examples/openclaw-tooling/README.md`](../examples/openclaw-tooling/README.md)
+- **Core-only working-context emulation** via [`examples/real-llm-smoke/README.md`](../examples/real-llm-smoke/README.md) lines 10-15:
+  > Core Track does not provide a working-context endpoint, so context assembly is intentionally emulated in the script.
+- **Core-only agent loop** via [`examples/agent-memory-loop/README.md`](../examples/agent-memory-loop/README.md) lines 13-18:
+  > Core Track only (`/memories/*` endpoints). No observability integration.
+
+## 5. Incorrect Assumptions or Risky Assumptions
+
+### 5.1 “StateLock sits between OpenClaw and the model API”
+
+This is the biggest architectural mismatch.
+
+Repo reality:
+
+- [`README.md`](../README.md) line 11 says StateLock handles memory persistence/retrieval and “does not route model calls.”
+- [`docs/run-with-local-first-stack.md`](../docs/run-with-local-first-stack.md) lines 3-10 and 36-75 keep Ollama/LiteLLM/OpenClaw/StateLock as separate concerns.
+
+Conclusion:
+
+- Treating StateLock as a first-class model gateway is **not a minimal extension**. It is a product-direction change.
+
+### 5.2 “New root subsystems can be added with minimal disruption”
+
+This is only partly true.
+
+Safe additions:
+
+- docs
+- examples
+- scripts
+- additive Observability modules
+
+Riskier additions:
+
+- new conversation-centric modules under root `app/`
+- new `/gateway/*` routes that re-scope Core
+
+Evidence:
+
+- [`docs/architecture-tracks.md`](../docs/architecture-tracks.md) lines 44-62 explicitly say post-promotion Observability should remain coherent and not be scattered across unrelated directories.
+
+### 5.3 “No required changes to `memory_service.py`, Chroma integration, existing endpoints”
+
+This is too strong.
+
+Why:
+
+- Current Core `MemoryService` is shaped around **memory blocks**, not conversation archives, transcript provenance, or gateway sessions.
+- If the repo adds raw archives, imported turns, provenance links, or gateway packet generation, those need new ownership, schemas, and likely new storage backends.
+
+Evidence:
+
+- [`app/services/memory_service.py`](../app/services/memory_service.py) lines 98-166 are about individual memory blocks.
+- [`app/services/memory_service.py`](../app/services/memory_service.py) lines 375-421 export/restore **session memory blocks**, not conversation archives.
+
+### 5.4 “Context Builder” belongs in Core right now
+
+Current repo evidence says the opposite.
+
+- Observability owns working-context construction in [`docs/architecture-tracks.md`](../docs/architecture-tracks.md#L25).
+- Core examples explicitly emulate context assembly client-side because Core does not expose that surface yet in [`examples/real-llm-smoke/README.md`](../examples/real-llm-smoke/README.md#L10).
+
+Conclusion:
+
+- A root-Core `app/context_builder/` is not the lowest-risk first move.
+
+### 5.5 Proposed crypto/PQC is implementation-ready
+
+This is unsupported by current repo evidence.
+
+Command evidence:
+
+```text
+$ rg -n "ML-KEM|ML-DSA|SLH-DSA|AES-256-GCM|wrapped_key|signature.sig|app/security" .
+[no relevant matches]
+```
+
+Conclusion:
+
+- Crypto design should be treated as **future / speculative**, not “next subsystem to add.”
+
+## 6. OpenClaw / Gateway Integration Recommendation
+
+### Recommendation
+
+Start OpenClaw integration as an **example integration / adapter contract**, not as a first-class gateway module inside Core.
+
+### Why
+
+- This matches the repo’s current role separation.
+- It preserves the current “StateLock is a memory sidecar” contract.
+- It allows incremental adoption without committing Core to model-routing responsibilities.
+
+Evidence:
+
+- [`examples/openclaw-tooling/README.md`](../examples/openclaw-tooling/README.md) lines 3-11 already define a minimal tool surface.
+- [`docs/run-with-local-first-stack.md`](../docs/run-with-local-first-stack.md) lines 36-75 already document the current operational flow.
+
+### Minimal API surface StateLock should expose first
+
+For OpenClaw, the lowest-risk first-class surfaces are probably:
+
+1. **Keep existing Core memory APIs**
+   - `POST /memories/`
+   - `POST /memories/query`
+   - `POST /memories/query-hybrid`
+   - session snapshot/restore
+2. **Optionally reuse Observability working-context API experimentally**
+   - `POST /v2/conversations/{conversation_id}/working_context`
+3. **Do not add `/gateway/*` yet**
+
+### Endpoint naming fit
+
+`/gateway/context` and `/gateway/memory` do **not** match the current API shape well.
+
+Current repo naming is resource-oriented:
+
+- Core: `/memories/*`, `/sessions`, `/tags`
+- Observability: `/v2/conversations/*`, `/v2/.../working_context`, `/v2/.../telemetry`
+
+If a future adapter API is needed, a more consistent fit would be:
+
+- keep it outside Core as example/tool code first
+- or, if eventually promoted, model it around existing nouns rather than a generic `/gateway/*` umbrella
+
+## 7. Import Pipeline Recommendation
+
+### Recommendation
+
+Treat historical import as an **Observability-first ingestion subsystem**, not as an immediate root-Core feature.
+
+### Why
+
+- Conversation import/export already exists in Observability.
+- Observability already owns turns, spans, working context, distillation, and replay-adjacent portability.
+- Historical imports are conversation-centric, not just memory-block-centric.
+
+Evidence:
+
+- [`experimental/observability/app/api/conversations.py`](../experimental/observability/app/api/conversations.py) lines 40-62
+- [`experimental/observability/app/services/export_import.py`](../experimental/observability/app/services/export_import.py) lines 71-121 and 124-260
+
+### Recommended first scope
+
+1. Define a **normalized conversation bundle schema** compatible with Observability import/export.
+2. Add importer/parser modules under **Observability** or a dedicated ingestion package adjacent to it.
+3. Keep raw archive storage additive and explicit.
+4. Only later decide whether distilled outputs should be projected into Core memory blocks.
+
+### Should raw archive store + distilled memory graph + context builder be treated as…
+
+- **raw archive store**: separate ingestion subsystem
+- **distilled memory**: background or offline pipeline, initially Observability-owned
+- **context builder**: existing Observability runtime component
+
+So the best classification is:
+
+- **separate ingestion subsystem + background pipeline**, not a simple extension of Core runtime.
+
+## 8. Encrypted Storage / PQC Recommendation
+
+### Recommendation
+
+Defer PQC and broad encrypted-storage architecture from the first implementation wave.
+
+### What is realistic now
+
+Near-term, low-risk options would be:
+
+- document security boundaries
+- define export-bundle integrity requirements
+- isolate where raw archives or export bundles would live on disk
+
+### What should be deferred
+
+- ML-KEM wrapped keys
+- ML-DSA or SLH-DSA signed bundles
+- full encrypted SQLite/raw archive/blob architecture
+- introducing a new `app/security/` subsystem before the import/archive model exists
+
+### Why
+
+- There is no current storage-crypto subsystem to extend.
+- Adding crypto boundaries before storage ownership is settled usually creates churn.
+
+Command evidence:
+
+```text
+$ rg -n "ML-KEM|ML-DSA|SLH-DSA|AES-256-GCM|wrapped_key|signature.sig|app/security" .
+[no relevant matches]
+```
+
+### Lowest-risk crypto boundary to introduce later
+
+If/when raw archives or export bundles become real, introduce crypto at the **bundle/archive boundary** first, not inside Core Chroma operations.
+
+## 9. Recommended Stable Interfaces to Define First
+
+These are the three most useful interfaces to define first.
+
+### 9.1 Normalized Conversation Bundle Interface
+
+Owner recommendation:
+
+- **Observability**
+
+Reason:
+
+- It already has `Conversation`, `Turn`, `Span`, `Thread`, `TelemetrySnapshot`, and `MemoryEntry` import/export machinery.
+
+Starting shape:
+
+```json
+{
+  "bundle_version": "statelock_bundle_v1",
+  "source_platform": "chatgpt|claude|markdown|telegram|discord|whatsapp",
+  "conversation": {
+    "external_id": "string",
+    "title": "string",
+    "created_at": "iso8601"
+  },
+  "turns": [
+    {
+      "turn_id": "string",
+      "speaker": "user|assistant|system|tool",
+      "text": "string",
+      "created_at": "iso8601",
+      "metadata": {}
+    }
+  ]
+}
+```
+
+### 9.2 External Adapter Contract for Agent Runtimes
+
+Owner recommendation:
+
+- **examples/** first, not Core runtime
+
+Reason:
+
+- This matches current OpenClaw sidecar/tool integration.
+
+Suggested initial contract:
+
+- query context from existing memory endpoints
+- optionally save memory blocks
+- keep model invocation outside StateLock
+
+This can stay as:
+
+- `memory.query`
+- `memory.save`
+- `memory.clear_session`
+
+before any first-class gateway route is introduced.
+
+### 9.3 Provenance Link Interface Between Imported Conversations and Distilled Memory
+
+Owner recommendation:
+
+- **Observability**
+
+Reason:
+
+- Distillation and import/export already live there.
+
+Suggested minimum fields:
+
+```json
+{
+  "memory_id": "uuid",
+  "conversation_id": "uuid",
+  "source_turn_ids": ["..."],
+  "source_span_ids": ["..."],
+  "origin_type": "imported|native|distilled",
+  "import_source": "chatgpt_export|claude_export|markdown|manual"
+}
+```
+
+This is compatible with current Observability distillation, which already records `source_turn_ids_json` and `source_span_ids_json` in [`experimental/observability/app/memory/distill.py`](../experimental/observability/app/memory/distill.py#L121).
+
+## 10. Lowest-Risk Implementation Sequence
+
+1. **Docs/ADR first**
+   - revise the proposed architecture so it respects the Core/Observability split
+   - explicitly classify gateway, import, and crypto as separate concerns
+2. **Observability import schema**
+   - formalize normalized conversation bundle format
+   - keep this under `experimental/observability/`
+3. **Example importers**
+   - implement one or two importers as experimental tooling
+   - likely ChatGPT export + markdown first
+4. **Observability provenance/distillation linkage**
+   - make imported turns/spans/distilled memory relationships explicit
+5. **OpenClaw adapter examples**
+   - extend `examples/openclaw-tooling/`
+   - optionally add example use of Observability working-context APIs
+6. **Evaluate promotion**
+   - only after interfaces settle, decide whether to promote import/distillation pieces out of `experimental/`
+7. **Deferred security layer**
+   - design encrypted bundles / signing only after archive/export formats stabilize
+
+## 11. File/Module Placement Recommendations
+
+### Put under `app/`
+
+Only if it is clearly Core memory-sidecar functionality:
+
+- additive memory-block APIs
+- Core insights
+- auth/config/runtime concerns directly tied to Core
+
+### Put under `experimental/`
+
+Recommended placement for now:
+
+- historical conversation importers
+- normalized conversation bundle schema
+- raw conversation archive handling
+- provenance tracker for imported conversations
+- conversation-level distillation extensions
+- context-builder evolution
+- replay/export/import work
+
+Reason:
+
+- This preserves the current two-track model and matches existing responsibilities in [`docs/architecture-tracks.md`](../docs/architecture-tracks.md#L14).
+
+### Put under `apps/web`
+
+Only UI support code:
+
+- inspection UIs for import bundles, replay, or provenance views
+- no backend business logic
+
+Evidence:
+
+- [`apps/web/README.md`](../apps/web/README.md) calls the Next app a thin UI.
+- [`apps/web/lib/proxy.ts`](../apps/web/lib/proxy.ts) only proxies to env-pinned upstreams.
+
+### Put under `scripts/`
+
+Good fit for:
+
+- one-off importer CLIs
+- archive bundle transforms
+- migration/validation helpers
+
+### Put under `docs/`
+
+Good fit for:
+
+- import bundle schema docs
+- gateway adapter contract docs
+- security ADRs for encrypted archive/export design
+
+## 12. Outstanding Questions or Decision Points
+
+1. Should imported conversation data remain purely Observability-owned, or should there be a later projection path into Core memory blocks?
+2. Is the long-term goal still to keep StateLock out of model routing entirely, or is there a deliberate future plan to make it a gateway/service mesh component?
+3. If chat importers are added, is the first desired output:
+   - replay/debugging,
+   - memory distillation,
+   - or both?
+4. Does raw archive storage need to be a filesystem tree, or can the first version rely on versioned portable bundles plus DB-backed normalized records?
+5. If crypto is added later, what is the first protected boundary:
+   - export bundle,
+   - raw archive,
+   - or full local DB?
+

--- a/docs/local-stack-minimal.md
+++ b/docs/local-stack-minimal.md
@@ -1,59 +1,70 @@
-LOCAL STACK MINIMAL CHEAT SHEET
-Only the commands you actually need
+# Local Stack Minimal Cheat Sheet
 
-⸻
+Only the commands you actually need.
 
-START WORK SESSION
-	1.	Make sure Ollama is running
+## Start Work Session
 
-Check:
+1. Make sure Ollama is running:
+
+```bash
 lsof -i :11434
+```
 
-If nothing shows:
+If nothing is listening:
+
+```bash
 ollama serve
-	2.	Start LiteLLM (only if building StateLock or agents)
+```
 
-~/venvs/litellm/bin/litellm –config ~/litellm.yaml –port 4000
+2. Start LiteLLM only when you need routed model calls:
 
-If you want it in background:
-nohup ~/venvs/litellm/bin/litellm –config ~/litellm.yaml –port 4000 > ~/litellm.log 2>&1 &
+```bash
+~/venvs/litellm/bin/litellm --config ~/litellm.yaml --port 4000
+```
 
-⸻
+Background mode:
 
-STOP LITELLM
+```bash
+nohup ~/venvs/litellm/bin/litellm --config ~/litellm.yaml --port 4000 > ~/litellm.log 2>&1 &
+```
 
-Kill all instances:
+3. Start the repo-local StateLock stack when needed:
+
+```bash
+make dev-up
+```
+
+## Stop LiteLLM
+
+```bash
 pkill -f litellm
-
-Confirm:
 lsof -i :4000
+```
 
-⸻
+## Verify LiteLLM
 
-VERIFY LITELLM IS WORKING
+```bash
+curl -s http://localhost:4000/v1/models | python3 -c 'import sys, json; data = json.load(sys.stdin); print([m["id"] for m in data["data"]])'
+```
 
-Check models:
-curl -s http://localhost:4000/v1/models | python3 -c ‘import sys,json; d=json.load(sys.stdin); print([m[“id”] for m in d[“data”]])’
+## Test a Local Model Through LiteLLM
 
-⸻
+```bash
+curl -s http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"chat_default","messages":[{"role":"user","content":"Say: ok"}],"max_tokens":10}'
+```
 
-TEST LOCAL MODEL THROUGH LITELLM
+## Chat Interface
 
-curl -s http://localhost:4000/v1/chat/completions -H “Content-Type: application/json” -d ‘{“model”:“chat_default”,“messages”:[{“role”:“user”,“content”:“Say: ok”}],“max_tokens”:10}’
+Local-only chat UI:
 
-⸻
+- `http://localhost:3000`
 
-CHAT INTERFACE
+## Remember
 
-Local-only chat:
-http://localhost:3000
+- Ollama = local engine
+- LiteLLM = router
+- StateLock = separate memory/continuity sidecar
 
-⸻
-
-REMEMBER
-
-Ollama = local engine
-LiteLLM = router
-StateLock = always talks to LiteLLM
-
-If you are just chatting, you do NOT need LiteLLM running.
+If you are just chatting in Ollama UI, you do not need LiteLLM running.

--- a/docs/local-stack.md
+++ b/docs/local-stack.md
@@ -1,158 +1,201 @@
-LOCAL LLM STACK DOCUMENTATION
-Mac Mini M4 · Ollama · LiteLLM · StateLock
+# Local LLM Stack
 
-⸻
+This document explains the surrounding local-first stack that StateLock commonly
+runs alongside.
 
-	1.	SYSTEM ARCHITECTURE
+## System Architecture
 
-Components
+Components:
 
-Ollama
-	•	Runs local models
-	•	Port: 11434
-	•	Used by Ollama UI and LiteLLM
+- Ollama
+  - runs local models
+  - default port: `11434`
+  - used by Ollama UI and LiteLLM
+- LiteLLM
+  - proxy router
+  - default port: `4000`
+  - exposes an OpenAI-style API
+  - routes to local Ollama models or configured cloud models
+- StateLock
+  - memory and continuity system
+  - does not route model calls
+  - can be used alongside LiteLLM-based agents and clients
 
-LiteLLM
-	•	Proxy router
-	•	Port: 4000
-	•	Provides OpenAI-style API
-	•	Routes to local (Ollama) or cloud (OpenAI)
+StateLock sits beside LiteLLM in this stack:
 
-StateLock
-	•	Will talk only to LiteLLM
-	•	Never directly to Ollama or OpenAI
+- model calls go to LiteLLM
+- memory/continuity calls go to StateLock
 
-⸻
+## Port Overview
 
-	2.	PORT OVERVIEW
+- `11434` = Ollama local model runtime
+- `3000` = Ollama Web UI
+- `4000` = LiteLLM proxy
+- `8000` = StateLock Core
+- `8001` = StateLock Observability when launched from repo root
+- `3001` = StateLock unified web UI when launched from repo root
 
-11434 = Ollama (local models)
-3000  = Ollama Web UI
-4000  = LiteLLM proxy
+## Normal Usage
 
-⸻
+Casual local chat:
 
-	3.	NORMAL USAGE
+- open `http://localhost:3000`
+- this talks directly to Ollama
+- LiteLLM is not required
 
-Casual Chat
-Open browser: http://localhost:3000
-This is 100 percent local. No LiteLLM involved.
+Programmatic agent/model calls:
 
-Programmatic / Agents
-Call: http://localhost:4000/v1/chat/completions
-This goes through LiteLLM and can route local first, cloud fallback.
+- call `http://localhost:4000/v1/chat/completions`
+- this goes through LiteLLM and can route local-first with optional cloud fallback
 
-⸻
+StateLock usage:
 
-	4.	STARTING SERVICES
+- call StateLock Core for memory APIs such as `/memories/*`
+- optionally call StateLock Observability for `/v2/*` continuity and telemetry APIs
+- StateLock itself remains separate from model routing
 
-Check if Ollama is running
+## Starting Services
+
+Check whether Ollama is running:
+
+```bash
 lsof -i :11434
+```
 
-If not running
+If it is not running:
+
+```bash
 ollama serve
+```
 
-Start LiteLLM (foreground)
-~/venvs/litellm/bin/litellm –config ~/litellm.yaml –port 4000
+Start LiteLLM in the foreground:
 
-Start LiteLLM (background)
-nohup ~/venvs/litellm/bin/litellm –config ~/litellm.yaml –port 4000 > ~/litellm.log 2>&1 &
+```bash
+~/venvs/litellm/bin/litellm --config ~/litellm.yaml --port 4000
+```
 
-⸻
+Start LiteLLM in the background:
 
-	5.	STOP LITELLM
+```bash
+nohup ~/venvs/litellm/bin/litellm --config ~/litellm.yaml --port 4000 > ~/litellm.log 2>&1 &
+```
 
-Check
+Start the StateLock repo-local stack after the repo environments are set up:
+
+```bash
+make dev-up
+```
+
+Useful repo-root companion commands:
+
+```bash
+make dev-status
+make dev-logs
+make dev-down
+```
+
+## Stop LiteLLM
+
+Check which process owns port `4000`:
+
+```bash
 lsof -i :4000
+```
 
-Kill specific process
+Kill a specific process:
+
+```bash
 kill PID_NUMBER
+```
 
-Kill all LiteLLM instances
+Kill all LiteLLM instances:
+
+```bash
 pkill -f litellm
+```
 
-⸻
+## Verify LiteLLM Is Running
 
-	6.	VERIFY LITELLM IS RUNNING
+Check available models:
 
-Check models
-curl -s http://localhost:4000/v1/models | python3 -c ‘import sys,json; d=json.load(sys.stdin); print([m[“id”] for m in d[“data”]])’
+```bash
+curl -s http://localhost:4000/v1/models | python3 -c 'import sys, json; data = json.load(sys.stdin); print([m["id"] for m in data["data"]])'
+```
 
-Expected output
-[‘chat_default’, ‘deep_default’, ‘code_default’, ‘cloud_code’, ‘cloud_reason’]
+Typical output:
 
-⸻
+```text
+['chat_default', 'deep_default', 'code_default', 'cloud_code', 'cloud_reason']
+```
 
-	7.	TEST CHAT THROUGH LITELLM
+## Test Chat Through LiteLLM
 
-curl -s http://localhost:4000/v1/chat/completions -H “Content-Type: application/json” -d ‘{“model”:“chat_default”,“messages”:[{“role”:“user”,“content”:“Say: banana”}],“max_tokens”:20}’
+```bash
+curl -s http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"chat_default","messages":[{"role":"user","content":"Say: banana"}],"max_tokens":20}'
+```
 
-⸻
+## Model Config File
 
-	8.	MODEL CONFIG FILE
+Typical location:
 
-Location
-~/litellm.yaml
+- `~/litellm.yaml`
 
-Local models
-chat_default → qwen2.5 7B
-deep_default → qwen2.5 14B
-code_default → qwen2.5-coder 7B
+Example aliases:
 
-Cloud models
-cloud_code → gpt-5.2-codex
-cloud_reason → gpt-5.2-chat-latest
+- local
+  - `chat_default`
+  - `deep_default`
+  - `code_default`
+- cloud
+  - `cloud_code`
+  - `cloud_reason`
 
-Guardrails disabled.
+Exact model mappings depend on your local `litellm.yaml`.
 
-⸻
+## Mental Model
 
-	9.	MENTAL MODEL
-
-Ollama = engine
-LiteLLM = switchboard
-StateLock = system using switchboard
+- Ollama = model engine
+- LiteLLM = model switchboard/router
+- StateLock = memory/continuity sidecar
 
 Ollama UI bypasses LiteLLM completely.
 
-StateLock must always use LiteLLM.
+## When To Run LiteLLM
 
-⸻
+Run it when:
 
-	10.	WHEN TO RUN LITELLM
+- developing or testing LiteLLM-routed model flows
+- building agents or client apps that call `/v1/chat/completions`
+- using fallback logic across local and cloud models
 
-Run it when
-	•	Developing StateLock
-	•	Testing routing
-	•	Using fallback logic
-	•	Building agents
+Do not run it when:
 
-Do not run it when
-	•	Just chatting locally
-	•	Not building
+- you are just chatting in Ollama UI
+- you are only working on StateLock memory APIs without any model-calling client flow
 
-⸻
+## OpenAI Key Setup
 
-	11.	OPENAI KEY SETUP
+Only required when LiteLLM is configured to call cloud models:
 
-Add to shell
-echo ‘export OPENAI_API_KEY=“YOUR_KEY”’ >> ~/.zshrc
+```bash
+echo 'export OPENAI_API_KEY="YOUR_KEY"' >> ~/.zshrc
 source ~/.zshrc
+```
 
-Only used when cloud models are called.
+## Clean Restart
 
-⸻
+```bash
+pkill -f litellm && ~/venvs/litellm/bin/litellm --config ~/litellm.yaml --port 4000
+```
 
-	12.	CLEAN RESTART
+## Canonical Repo Location
 
-pkill -f litellm && ~/venvs/litellm/bin/litellm –config ~/litellm.yaml –port 4000
+The canonical repo path used throughout the current docs is:
 
-⸻
+- `~/projects/statelock-engine`
 
-	13.	STATELOCK PROJECT LOCATION
+Legacy client example:
 
-~/projects/statelock-seed
-
-Run client
-npx tsx src/client.ts “Your prompt”
-
+- `examples/statelock-seed-client/`

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -1,6 +1,6 @@
 # Operator Runbook
 
-## Local dev run
+## Local dev run (Core only)
 
 ```bash
 python3 -m venv .venv
@@ -8,6 +8,22 @@ source .venv/bin/activate
 make setup-dev
 cp .env.example .env
 make run
+```
+
+## Local full-stack run (recommended for repo work)
+
+After the Core, Observability, and web environments are prepared:
+
+```bash
+make dev-up
+make dev-status
+make dev-logs
+```
+
+Stop the full stack:
+
+```bash
+make dev-down
 ```
 
 ## Docker run (dev)
@@ -48,14 +64,15 @@ python scripts/session_snapshot_cli.py import \
 
 1. Pull latest code.
 2. Review `CHANGELOG.md` for interface/env changes.
-3. Rebuild/restart:
+3. If `apps/web` is present, run `make web-check`.
+4. Rebuild/restart:
 
 ```bash
 make down-prod
 make up-prod
 ```
 
-4. Verify readiness:
+5. Verify readiness:
 
 ```bash
 curl -sS http://127.0.0.1:8000/healthz

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,9 +4,10 @@
 
 1. Ensure branch is up to date with `main`.
 2. Run `make lint` and `make test`.
-3. Verify `.env.example` matches current required env vars.
-4. Confirm docs updates for any public interface changes.
-5. Update `CHANGELOG.md` under `[Unreleased]`.
+3. Run `make web-check` when `apps/web` is present.
+4. Verify `.env.example` matches current required env vars.
+5. Confirm docs updates for any public interface changes.
+6. Update `CHANGELOG.md` under `[Unreleased]`.
 
 ## Version cut
 
@@ -23,4 +24,5 @@
    - `GET /healthz`
    - `GET /readyz`
    - one `memory.query` + one `memory.save` flow
-3. Archive exported snapshot fixture for rollback testing.
+3. Smoke test the unified web UI when `apps/web` ships in the release.
+4. Archive exported snapshot fixture for rollback testing.

--- a/docs/run-with-local-first-stack.md
+++ b/docs/run-with-local-first-stack.md
@@ -11,6 +11,14 @@ StateLock does not route models in this architecture.
 
 ## 1) Start StateLock
 
+Preferred full-stack path from repo root once local environments are set up:
+
+```bash
+make dev-up
+```
+
+Core-only Docker path:
+
 ```bash
 cp .env.example .env
 make up
@@ -20,6 +28,7 @@ API docs:
 
 - `http://127.0.0.1:8000/docs`
 - Console (local): `http://127.0.0.1:8000/app`
+- Unified UI (when using `make dev-up`): `http://127.0.0.1:3001`
 
 ## 2) Keep your existing LiteLLM aliases
 

--- a/docs/statelock-cognitive-architecture.md
+++ b/docs/statelock-cognitive-architecture.md
@@ -1,0 +1,455 @@
+# StateLock Cognitive Architecture
+
+## StateLock System Mental Model
+
+StateLock is best understood as a **continuity layer** with two cooperating tracks:
+
+- **Core Track** provides stable durable memory operations.
+- **Observability Track** provides conversation structure, working context, telemetry, governance, and distillation.
+
+External systems such as OpenClaw, bots, agent runtimes, and CLI tools sit outside StateLock and call into it through existing APIs and adapter contracts.
+
+Evidence:
+
+- [`docs/architecture-tracks.md`](../docs/architecture-tracks.md) lines 3-6 define the two-track model.
+- [`README.md`](../README.md) lines 3-17 define StateLock as a memory sidecar and say it does not route model calls.
+- [`docs/local-stack.md`](../docs/local-stack.md) lines 15-24 and 110-119 place LiteLLM in the router role and StateLock in the continuity/memory role.
+- [`examples/openclaw-tooling/README.md`](../examples/openclaw-tooling/README.md) lines 3-11 show current adapter-style tool usage.
+
+## Key Design Idea
+
+The key idea is:
+
+- **Core** remembers durable memory blocks.
+- **Observability** understands conversation state and selects what matters now.
+- **Adapters** let external systems consume those capabilities without turning StateLock into a model gateway.
+
+This means StateLock’s value is not just storage. It is the combination of:
+
+- durable memory
+- context hygiene
+- traceability
+- distillation
+- continuity across agent runs
+
+## What Each Layer Does
+
+### Core Track (Stable Runtime)
+
+Core owns:
+
+- memory block storage
+- memory retrieval
+- session snapshots and restore
+- insights (`/stats/overview`, `/sessions`, `/tags`)
+- health/readiness
+- Chroma-backed persistence
+
+Evidence:
+
+- [`README.md`](../README.md) lines 19-32
+- [`app/core/database.py`](../app/core/database.py) lines 10-20
+- [`app/routers/memories.py`](../app/routers/memories.py) lines 29-99
+- [`app/routers/insights.py`](../app/routers/insights.py) lines 14-39
+- [`app/services/memory_service.py`](../app/services/memory_service.py) lines 98-166, 167-257, and 375-421
+
+### Observability Track (Continuity Engine)
+
+Observability owns:
+
+- conversations
+- turns
+- spans
+- working-context construction
+- telemetry
+- governance
+- import/export bundles
+- memory distillation
+- run traceability
+
+Evidence:
+
+- [`docs/architecture-tracks.md`](../docs/architecture-tracks.md) lines 25-34
+- [`experimental/observability/README.md`](../experimental/observability/README.md) lines 13-20
+- [`experimental/observability/app/main.py`](../experimental/observability/app/main.py) lines 42-55
+- [`experimental/observability/app/api/conversations.py`](../experimental/observability/app/api/conversations.py) lines 40-62
+- [`experimental/observability/app/api/context.py`](../experimental/observability/app/api/context.py) lines 16-46
+- [`experimental/observability/app/api/telemetry.py`](../experimental/observability/app/api/telemetry.py) lines 25-132
+- [`experimental/observability/app/api/governance.py`](../experimental/observability/app/api/governance.py) lines 16-56
+- [`experimental/observability/app/api/memory.py`](../experimental/observability/app/api/memory.py) lines 16-45
+
+### Distilled Memory Layer
+
+The distilled-memory idea is conceptually correct, but the repo nuance matters:
+
+- **today**: distillation creates Observability `MemoryEntry` records
+- **future possibility**: some distilled outputs may be projected into Core memory blocks
+
+What is true now:
+
+- Distillation exists in Observability via [`experimental/observability/app/memory/distill.py`](../experimental/observability/app/memory/distill.py) lines 88-158.
+- Distilled records currently live in Observability’s `MemoryEntry` model in [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py) lines 112-130.
+
+What is **not** proven now:
+
+- automatic promotion of distilled Observability memory into Core Chroma blocks
+
+So the statement “distilled memory becomes Core memory blocks” is best treated as:
+
+- **directionally valid future architecture**
+- **not current implementation reality**
+
+### Adapter Layer (Integration Surface)
+
+The adapter layer consists of:
+
+- OpenClaw tools/hooks
+- agent runtimes
+- CLI workflows
+- example adapters
+
+These should interact with:
+
+- Core memory APIs for save/query/session behavior
+- Observability context/telemetry APIs when richer continuity is needed
+
+They should **not** force StateLock to become a model router.
+
+Evidence:
+
+- [`docs/run-with-local-first-stack.md`](../docs/run-with-local-first-stack.md) lines 36-43
+- [`examples/openclaw-tooling/AUTOMATION_CONTRACT.md`](../examples/openclaw-tooling/AUTOMATION_CONTRACT.md) lines 5-30 and 42-79
+- [`examples/openclaw-tooling/AUTOMATION_CONTRACT.md`](../examples/openclaw-tooling/AUTOMATION_CONTRACT.md) line 98:
+  > Cloud escalation remains in agent/router layer; `confidence_low` is only a hint signal.
+
+## The Three Interfaces That Matter
+
+### 1. Normalized conversation bundle schema
+
+Purpose:
+
+- normalize imported chat/export formats before ingestion
+
+Best owner:
+
+- Observability
+
+Why:
+
+- import/export bundles already exist there
+
+Evidence:
+
+- [`experimental/observability/app/api/conversations.py`](../experimental/observability/app/api/conversations.py) lines 40-62
+- [`experimental/observability/app/services/export_import.py`](../experimental/observability/app/services/export_import.py) lines 71-121 and 124-260
+
+### 2. Provenance link model
+
+Purpose:
+
+- connect imported conversations, distilled observations, and any later Core memory projection
+
+Best owner:
+
+- Observability first
+
+Why:
+
+- provenance already exists around spans and distilled memory sources
+
+Evidence:
+
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py) lines 46-64
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py) lines 112-130
+- [`experimental/observability/app/memory/distill.py`](../experimental/observability/app/memory/distill.py) lines 121-123
+
+### 3. External adapter contract for agents and gateways
+
+Purpose:
+
+- expose StateLock memory/context capabilities to OpenClaw-style systems without turning StateLock into a model gateway
+
+Best owner:
+
+- examples/contracts first, runtime promotion later if needed
+
+Evidence:
+
+- [`examples/openclaw-tooling/AUTOMATION_CONTRACT.md`](../examples/openclaw-tooling/AUTOMATION_CONTRACT.md)
+- [`examples/openclaw-tooling/README.md`](../examples/openclaw-tooling/README.md)
+
+## Post-1.0 Possibilities
+
+Post-1.0, the repo may promote Observability into a cohesive `app/observability/` subsystem.
+
+That is already anticipated in:
+
+- [`docs/architecture-tracks.md`](../docs/architecture-tracks.md) lines 44-62
+
+The important constraint is that promotion should preserve subsystem coherence:
+
+- Core remains the stable memory runtime
+- Observability remains the conversation/traceability/continuity subsystem
+- adapters remain at the integration edge
+
+## The Real Product Vision
+
+The real product vision is not “vector DB plus memory CRUD.”
+
+It is:
+
+- durable memory
+- context selection
+- continuity across runs
+- replay and traceability
+- outcome-informed refinement
+
+That is why the two-track model is strong:
+
+- Core stays boring and dependable
+- Observability carries the more experimental continuity intelligence
+
+## The Clean Mental Model
+
+The cleanest repo-aligned mental model is:
+
+```text
+External agents / tools / adapters
+            |
+            v
+        StateLock
+
+  Core Track                Observability Track
+  ----------                -------------------
+  memory blocks             conversations
+  retrieval                 turns / spans / threads
+  snapshots                 working context
+  insights                  telemetry
+  Chroma persistence        governance
+                            distillation
+                            import/export
+                            provenance / replay
+```
+
+That is accurate to the current repo.
+
+The only correction to the proposed mental model is:
+
+- “Distilled memory becomes Core memory blocks” should be rewritten as:
+  - **distilled memory currently lives in Observability**
+  - **it may later be projected into Core memory blocks**
+
+## StateLock Cognitive Loop
+
+The proposed cognitive loop is a good conceptual model:
+
+```text
+Conversation
+-> Observation
+-> Distillation
+-> Memory
+-> Experience
+-> Context
+-> Reasoning
+-> Outcome
+```
+
+But it needs repo-grounded interpretation.
+
+## What Each Stage Does
+
+### Conversation
+
+Conversation is the raw sequence of turns and related metadata.
+
+Repo evidence:
+
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py) lines 16-44 define `Conversation` and `Turn`.
+
+### Observation
+
+Observation corresponds to extracting structured evidence spans and thread assignments from conversation turns.
+
+Repo evidence:
+
+- [`experimental/observability/README.md`](../experimental/observability/README.md) lines 13-20
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py) lines 46-79 define `Span` and `Thread`
+
+### Distillation
+
+Distillation turns recent conversation evidence into reusable memory entries.
+
+Repo evidence:
+
+- [`experimental/observability/app/memory/distill.py`](../experimental/observability/app/memory/distill.py) lines 88-158
+
+### Memory
+
+There are two memory notions in the repo:
+
+1. **Core memory blocks** in Chroma
+2. **Observability memory entries** derived from conversations
+
+That duality is why the continuity-layer framing matters.
+
+Evidence:
+
+- [`app/core/database.py`](../app/core/database.py) lines 10-20
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py) lines 112-130
+
+### Experience
+
+Experience is not a first-class subsystem yet, but it is a plausible next concept.
+
+The repo already has building blocks for it:
+
+- telemetry snapshots with metrics and actions
+- governance events
+- memory entries with `success_count`, `failure_count`, and `last_applied_at`
+- pipeline logs
+
+Evidence:
+
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py) lines 95-110 define `TelemetrySnapshot`
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py) lines 127-129 define `success_count`, `failure_count`, `last_applied_at`
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py) lines 132-151 define `GovernanceEvent` and `PipelineLog`
+- [`experimental/observability/app/api/telemetry.py`](../experimental/observability/app/api/telemetry.py) lines 90-132 expose run-group and snapshot explainability
+- [`experimental/observability/app/api/governance.py`](../experimental/observability/app/api/governance.py) lines 16-56 expose governance actions and logs
+
+This makes the “Experience layer” **viable**, and it fits naturally under:
+
+- `experimental/observability/`
+
+### Context
+
+Context is the bounded, model-visible working set built from procedures, spans, recent turns, and evidence selection logic.
+
+Repo evidence:
+
+- [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py) lines 135-200
+
+### Reasoning
+
+Reasoning remains external to StateLock’s current backend runtime.
+
+It happens in:
+
+- LiteLLM / model runtime
+- external agents like OpenClaw
+
+Repo evidence:
+
+- [`README.md`](../README.md) lines 11-17
+- [`docs/local-stack.md`](../docs/local-stack.md) lines 15-24
+
+### Outcome
+
+Outcome is what the agent/model produced, plus what telemetry/governance later records about whether the context and strategy were good.
+
+Repo evidence:
+
+- telemetry run groups and explainability in [`experimental/observability/app/api/telemetry.py`](../experimental/observability/app/api/telemetry.py)
+- governance log in [`experimental/observability/app/api/governance.py`](../experimental/observability/app/api/governance.py)
+
+## Why This Loop Matters
+
+This loop matters because it explains how StateLock can evolve beyond “just memory retrieval” without forcing all responsibilities into Core.
+
+It gives the repo a coherent future story:
+
+- Core stores durable memory
+- Observability turns runs into structured continuity signals
+- adapters consume those signals
+
+That preserves the current architecture while still supporting the long-term continuity-layer vision.
+
+## Where Each Part Lives in the Repo
+
+| Concept | Current repo home |
+|---|---|
+| memory blocks | `app/core/`, `app/services/memory_service.py`, `app/routers/memories.py` |
+| insights | `app/routers/insights.py` |
+| health/readiness | `main.py` |
+| conversations / turns / spans | `experimental/observability/app/db/`, `experimental/observability/app/api/` |
+| working context | `experimental/observability/app/context_builder/`, `experimental/observability/app/api/context.py` |
+| telemetry | `experimental/observability/app/api/telemetry.py`, `experimental/observability/app/telemetry/` |
+| governance | `experimental/observability/app/api/governance.py`, `experimental/observability/app/governance/` |
+| distillation | `experimental/observability/app/memory/` |
+| adapter examples | `examples/openclaw-tooling/` |
+
+## Architectural Insight
+
+The architecture is sound if read this way:
+
+- Core is the stable substrate.
+- Observability is the continuity engine.
+- Adapters are the integration surface.
+
+That keeps the repo modular and lets more experimental reasoning-support features mature without destabilizing the canonical memory runtime.
+
+## Why This Architecture Is Strong
+
+This architecture is strong because it avoids two common failures:
+
+1. putting too much experimental reasoning logic into the stable runtime
+2. treating memory as only vector retrieval instead of continuity management
+
+The repo already has the beginnings of a stronger pattern:
+
+- a dependable Core
+- an experimental but substantial Observability subsystem
+- explicit adapter boundaries
+
+## The StateLock Superpower
+
+StateLock’s superpower is not only remembering.
+
+It is:
+
+- deciding what matters from prior interaction
+- making that context inspectable
+- preserving provenance
+- enabling better future reuse
+
+That is why the continuity-layer framing is useful, as long as it stays grounded in the current track boundaries.
+
+## Long-Term Possibility
+
+A plausible long-term direction is:
+
+- imported conversations feed Observability
+- Observability extracts distilled and experience-informed knowledge
+- selected stable outputs are projected into Core memory blocks
+- adapters consume both durable memory and contextual continuity surfaces
+
+That is a realistic evolution from the current repo, and it does not require StateLock to become a model router.
+
+## The One Diagram Explaining the Project
+
+```text
+Ollama = model runtime
+LiteLLM = model router
+OpenClaw / agents / tools = integration edge
+
+                external adapters
+                       |
+                       v
+                  StateLock
+         ---------------------------
+         |                         |
+         v                         v
+      Core Track            Observability Track
+   memory sidecar           continuity engine
+   - memory blocks          - conversations
+   - retrieval              - spans / threads
+   - snapshots              - working context
+   - insights               - telemetry
+   - Chroma                 - governance
+                             - distillation
+                             - import/export
+                             - provenance
+
+Reasoning/model invocation stays outside StateLock.
+Continuity emerges from Core durability + Observability context intelligence.
+```
+

--- a/examples/statelock-seed-client/README.md
+++ b/examples/statelock-seed-client/README.md
@@ -1,8 +1,12 @@
 # statelock-seed Client Example
 
-This directory is the canonical home for the seed TypeScript client used to test local-first model routing patterns.
+This directory contains the legacy `statelock-seed` TypeScript client example used
+to test local-first model routing patterns.
 
 It is a consumer example, not runtime server code.
+
+The `statelock-seed` name is retained for provenance and continuity with the
+earlier seed repo.
 
 ## Scope
 

--- a/experimental/observability/README.md
+++ b/experimental/observability/README.md
@@ -33,6 +33,11 @@ pip install -e ".[dev]"
 uvicorn app.main:app --reload --host 127.0.0.1 --port 8000
 ```
 
+Repo-root launcher note:
+
+- standalone Observability defaults to `127.0.0.1:8000`
+- the repo-root `make dev-up` launcher runs Observability on `127.0.0.1:8001` to avoid conflicting with Core on `127.0.0.1:8000`
+
 ## DB Location
 Default database path is `./data/statelock_v2.db`.
 

--- a/experimental/observability/docs/FIRST_30_MINUTES.md
+++ b/experimental/observability/docs/FIRST_30_MINUTES.md
@@ -18,6 +18,9 @@ pip install -e ".[dev]"
 uvicorn app.main:app --reload --host 127.0.0.1 --port 8000
 ```
 
+If you are running the whole repo from the root launcher, Observability is started
+for you on `127.0.0.1:8001` via `make dev-up`.
+
 Expected:
 - server starts without import/setup errors
 - startup logs include the resolved SQLite path

--- a/experimental/observability/docs/REPO_GUIDE.md
+++ b/experimental/observability/docs/REPO_GUIDE.md
@@ -236,6 +236,11 @@ pip install -e ".[dev]"
 uvicorn app.main:app --reload --host 127.0.0.1 --port 8000
 ```
 
+Repo-root launcher note:
+
+- standalone Observability uses `127.0.0.1:8000`
+- repo-root `make dev-up` launches Observability on `127.0.0.1:8001`
+
 ### DB location
 Default SQLite path is `./data/statelock_v2.db`.
 


### PR DESCRIPTION
# Summary

This PR does a documentation alignment pass across the repo and adds a set of architecture docs that capture the current two-track model in a repo-grounded way. The main user-facing effect is that the GitHub landing page, local stack docs, runbooks, release notes, and observability onboarding docs now describe the repo as it actually exists today rather than mixing current behavior with older local-stack assumptions.

It also deliberately keeps the local `docs/codex-rehydration-prompt.md` out of version control by adding it to `.gitignore`, while committing the architecture documents themselves because they are substantive repo docs rather than local scratch notes.

# Problem

The documentation surface had drifted in a few important ways:

- the root README was still underspecified about the current two-track architecture and current CI shape
- the local-stack docs still implied that StateLock itself talks only to LiteLLM, which conflicts with the repo’s actual role split where LiteLLM routes models and StateLock handles memory/continuity
- some docs still referenced the old `statelock-seed` repo path even though this is now the canonical `statelock-engine` repo
- observability startup docs described standalone port `8000` without clarifying that the repo-root launcher runs Observability on `8001` to coexist with Core on `8000`
- the public changelog still contained placeholder text rather than real unreleased notes

For users landing on GitHub or trying to run the repo locally, that mismatch makes the project look less coherent than it is and increases the chance of starting the wrong service on the wrong port or misunderstanding where architecture work belongs.

# Root Cause

Most of the drift came from recent consolidation work moving the repo toward a cleaner Core plus Observability split, while some operator docs and local-stack notes still reflected older seed-repo or single-service assumptions. At the same time, the architecture docs on this branch existed only as untracked local files, so none of that clarified architecture direction was visible remotely.

# Fix

This PR addresses that in three buckets.

First, it adds the architecture doc set to the branch and remote:

- `docs/architecture-sanity-check.md`
- `docs/architecture-continuity-layer.md`
- `docs/statelock-cognitive-architecture.md`
- `docs/architecture-memory-stratification.md`
- `docs/architecture-promotion-engine.md`
- `docs/architecture-promotion-schemas.md`
- `docs/architecture-memory-graph.md`
- `docs/architecture-memory-policy-profiles.md`

These docs are intentionally explicit about the distinction between implemented behavior, partially represented behavior, and conceptual future architecture. They keep Core narrow, place richer continuity systems in Observability first, and describe projection into Core as a narrow and auditable boundary rather than a broad rewrite.

Second, it updates the operational and public-facing docs to match current repo reality:

- `README.md` now explains the two-track layout, distinguishes Core-only quickstart from the repo-root full-stack launcher, reflects current CI coverage, and clarifies the website/docs situation
- `docs/local-stack.md` and `docs/local-stack-minimal.md` were rewritten to remove the misleading “StateLock talks only to LiteLLM” framing and to describe LiteLLM as the model router beside StateLock rather than inside it
- `docs/run-with-local-first-stack.md`, `docs/operator-runbook.md`, and `docs/release-checklist.md` now reference the repo-root launcher and current supporting commands more accurately
- `experimental/observability/README.md`, `experimental/observability/docs/FIRST_30_MINUTES.md`, and `experimental/observability/docs/REPO_GUIDE.md` now clarify the difference between standalone Observability startup on `8000` and repo-root launcher startup on `8001`
- `CHANGELOG.md` replaces placeholder unreleased text with a real note about the documentation alignment work
- `examples/statelock-seed-client/README.md` now explicitly marks that example as legacy seed-provenance material rather than implying it is the canonical client path today

Third, it keeps the local operator prompt out of git by adding `docs/codex-rehydration-prompt.md` to `.gitignore`.

# Validation

I ran the standard repo checks after the docs changes:

- `make test`: passed (`11 passed`)
- `make web-check`: passed (`npm run lint`, `npm run typecheck`, and `npm run build` all succeeded)
- `make lint`: failed, but due to pre-existing observability lint debt already present in tracked Python files under `experimental/observability/` rather than due to this documentation diff

The lint failure is worth keeping visible in the PR because it is current repo baseline state, but it is not introduced by this branch.

# Notes For Review

The architecture docs are intentionally documentation-first. They describe the current codebase boundaries and future-facing design direction, but they do not claim that the proposed promotion, graph, or policy-profile systems already exist as runtime features. Where the repo already has adjacent implementations, the docs point to those concrete files; where the ideas are still conceptual, the docs call that out directly.
