### PR TITLE
docs: prepare v0.4.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,39 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on Keep a Changelog and this project follows SemVer.
+---
 
 ## [Unreleased]
 
 ### Changed
-- Documentation updated to reflect the repo-root launcher, current track boundaries, current CI checks, and the canonical `statelock-engine` repo path.
+- documentation updates for launcher, track boundaries, CI checks, and canonical repo path
+
+---
+
+## [0.4.0] - 2026-03-06
+
+### Added
+- Humane product UI
+- Product navigation: Overview, Conversations, Highlights, Memory, Relationships, Runs, Learning Mode
+- Overview continuity funnel visualization
+- Relationships inspector for provenance and contradictions
+- Learning Mode UI exposing stable conversation settings
+
+### Architecture
+- Product UI added alongside existing operator/debug routes
+- Core vs Observability boundaries preserved
+- Humane labels used across product UI with technical detail drawers
+
+### Known Limitations
+- No first-class candidate-memory read model yet
+- Runs remain conversation-scoped
+- Relationship graph visualization deferred until a stable read model exists
+
+---
 
 ## [0.3.0] - 2026-02-17
 
 ### Added
-- Hybrid query endpoint, snapshot/restore, and structured error envelope.
+- Hybrid query endpoint
+- Snapshot/restore
+- Structured error envelope


### PR DESCRIPTION
## Summary
This PR updates `CHANGELOG.md` for the first Product UI release.

It preserves the existing `0.3.0` entry intact and adds a new `0.4.0` entry above it for the Product UI milestone, while keeping `[Unreleased]` at the top.

## Why
`0.3.0` is already claimed in the changelog for a different milestone, even though no corresponding tag or GitHub release exists. Reusing `0.3.0` for the Product UI release would create ambiguity in release history.

This PR makes the release history explicit before tagging:
- `0.3.0` remains associated with the earlier hybrid query / snapshot-restore milestone
- `0.4.0` becomes the first humane Product UI release

## Included changelog sections
`0.4.0` documents:
- humane product UI
- product navigation for Overview, Conversations, Highlights, Memory, Relationships, Runs, and Learning Mode
- the continuity funnel
- inspector-first relationships
- read-mostly Learning Mode
- architecture boundaries and known limitations
