### PR TITLE
dev: make local launcher idempotent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,19 +37,13 @@ dev-status:
 	bash scripts/dev-status.sh
 
 dev-restart:
-	$(MAKE) dev-down
-	$(MAKE) dev-up
+	bash scripts/dev-restart.sh
 
 dev-logs:
 	bash scripts/dev-logs.sh
 
 dev-open:
-	@if command -v open >/dev/null 2>&1; then \
-		open http://127.0.0.1:3001; \
-	else \
-		echo "macOS 'open' command not available; open http://127.0.0.1:3001 manually."; \
-		exit 1; \
-	fi
+	bash scripts/dev-open.sh
 
 up:
 	cp -n .env.example .env || true

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ from repo root with one command:
 make dev-up
 ```
 
+`make dev-up` is idempotent: it ensures Core, Observability, and the UI are
+running, reuses healthy services that are already up, repairs stale PID files,
+and reports clear port conflicts instead of treating "already running" as a hard
+failure.
+
 Launcher prerequisites:
 
 - Core virtualenv: `python3 -m venv .venv && source .venv/bin/activate && make setup-dev`
@@ -83,6 +88,8 @@ macOS-only helper:
 ```bash
 make dev-open
 ```
+
+`make dev-open` first ensures the local stack is up, then opens the product UI.
 
 Runtime artifacts are stored locally in `.run/`:
 

--- a/scripts/dev-open.sh
+++ b/scripts/dev-open.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/dev-common.sh
+source "$SCRIPT_DIR/lib/dev-common.sh"
+
+bash "$SCRIPT_DIR/dev-up.sh"
+
+if command -v open >/dev/null 2>&1; then
+  open "$WEB_URL"
+  printf "Opened %s\n" "$WEB_URL"
+else
+  printf "UI is ready at %s\n" "$WEB_URL"
+fi

--- a/scripts/dev-restart.sh
+++ b/scripts/dev-restart.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+printf "Restarting StateLock local stack...\n"
+bash "$SCRIPT_DIR/dev-down.sh"
+printf "\n"
+bash "$SCRIPT_DIR/dev-up.sh"

--- a/scripts/dev-status.sh
+++ b/scripts/dev-status.sh
@@ -6,7 +6,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/dev-common.sh
 source "$SCRIPT_DIR/lib/dev-common.sh"
 
-printf "StateLock local stack status\n\n"
-print_status_line core
-print_status_line obs
-print_status_line web
+printf "StateLock Stack Status\n\n"
+printf "Overall: %s\n\n" "$(stack_overall_status)"
+print_status_block core
+printf "\n"
+print_status_block obs
+printf "\n"
+print_status_block web

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -7,38 +7,53 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/dev-common.sh"
 
 rollback() {
-  printf "\nStartup failed. Stopping any services started in this attempt...\n" >&2
-  stop_service web >/dev/null 2>&1 || true
-  stop_service obs >/dev/null 2>&1 || true
-  stop_service core >/dev/null 2>&1 || true
+  local service
+  if [[ "${#STARTED_SERVICES[@]}" -eq 0 ]]; then
+    printf "\nStartup failed. No newly started services to roll back.\n" >&2
+    return
+  fi
+
+  printf "\nStartup failed. Stopping services started in this attempt...\n" >&2
+  for (( idx=${#STARTED_SERVICES[@]}-1 ; idx>=0 ; idx-- )); do
+    service="${STARTED_SERVICES[idx]}"
+    stop_service "$service" >/dev/null 2>&1 || true
+  done
 }
+
+STARTED_SERVICES=()
 
 trap rollback ERR
 
 check_prereqs
-check_port_available core
-check_port_available obs
-check_port_available web
 
-printf "Starting Core on %s...\n" "$CORE_URL"
-start_service core
-wait_for_http core "$CORE_URL/healthz" 30
-wait_for_http core "$CORE_URL/readyz" 30
+ensure_service_running core "Core"
+if [[ "$ENSURE_SERVICE_ACTION" == "started" ]]; then
+  STARTED_SERVICES+=(core)
+fi
 
-printf "Starting Observability on %s...\n" "$OBS_URL"
-start_service obs
-wait_for_http obs "$OBS_URL/health" 30
+ensure_service_running obs "Observability"
+if [[ "$ENSURE_SERVICE_ACTION" == "started" ]]; then
+  STARTED_SERVICES+=(obs)
+fi
 
-printf "Starting UI on %s...\n" "$WEB_URL"
-start_service web
-wait_for_http web "$WEB_URL/api/core/healthz" 45
+ensure_service_running web "UI"
+if [[ "$ENSURE_SERVICE_ACTION" == "started" ]]; then
+  STARTED_SERVICES+=(web)
+fi
 
 trap - ERR
 
 printf "\nStateLock local stack is up.\n"
+printf "Overall       %s\n" "$(stack_overall_status)"
 printf "Core          %s\n" "$CORE_URL"
 printf "Observability %s\n" "$OBS_URL"
 printf "UI            %s\n" "$WEB_URL"
+printf "\nStatus:\n"
+print_status_block core
+printf "\n"
+print_status_block obs
+printf "\n"
+print_status_block web
 printf "\nLogs:\n"
 printf "  core: %s\n" "$CORE_LOG_FILE"
 printf "  obs:  %s\n" "$OBS_LOG_FILE"

--- a/scripts/lib/dev-common.sh
+++ b/scripts/lib/dev-common.sh
@@ -25,6 +25,7 @@ WEB_URL="http://127.0.0.1:${WEB_PORT}"
 
 OBS_API_KEY="${STATELOCK_OBS_API_KEY:-dev-key}"
 CORE_API_KEY="${STATELOCK_CORE_API_KEY:-}"
+ENSURE_SERVICE_ACTION=""
 
 mkdir -p "$LOG_DIR"
 
@@ -69,6 +70,36 @@ pid_is_running() {
   kill -0 "$pid" 2>/dev/null
 }
 
+process_command() {
+  local pid="$1"
+  ps -p "$pid" -o command= 2>/dev/null || true
+}
+
+pid_matches_service() {
+  local service="$1"
+  local pid="$2"
+  local command
+  command="$(process_command "$pid")"
+  if [[ -z "$command" ]]; then
+    return 1
+  fi
+
+  case "$service" in
+    core)
+      [[ "$command" == *"uvicorn main:app"* ]]
+      ;;
+    obs)
+      [[ "$command" == *"uvicorn app.main:app"* ]]
+      ;;
+    web)
+      [[ "$command" == *"npm run dev"* || "$command" == *"next dev"* || "$command" == *"next/dist/bin/next"* ]]
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 read_pid() {
   local pid_file="$1"
   if [[ -f "$pid_file" ]]; then
@@ -82,8 +113,19 @@ clear_stale_pid() {
   pid_file="$(service_pid_file "$service")"
   local pid
   pid="$(read_pid "$pid_file")"
-  if [[ -n "${pid:-}" ]] && ! pid_is_running "$pid"; then
+  if [[ -z "${pid:-}" ]]; then
+    return 0
+  fi
+
+  if ! pid_is_running "$pid"; then
     rm -f "$pid_file"
+    printf "%s: repaired stale pid file (%s was not running)\n" "$service" "$pid" >&2
+    return 0
+  fi
+
+  if ! pid_matches_service "$service" "$pid"; then
+    rm -f "$pid_file"
+    printf "%s: repaired stale pid file (%s did not match expected process)\n" "$service" "$pid" >&2
   fi
 }
 
@@ -104,6 +146,11 @@ service_pid_status() {
 port_listener() {
   local port="$1"
   lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true
+}
+
+port_listener_pids() {
+  local port="$1"
+  lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true
 }
 
 ensure_command() {
@@ -135,24 +182,6 @@ check_prereqs() {
   ensure_file "$REPO_ROOT/experimental/observability/.venv/bin/python" "from repo root run: cd experimental/observability && python3.11 -m venv .venv && ./.venv/bin/python -m pip install -e '.[dev]'"
   ensure_file "$REPO_ROOT/apps/web/package-lock.json" "restore or create apps/web/package-lock.json before using the launcher"
   ensure_file "$REPO_ROOT/apps/web/node_modules/next/package.json" "from repo root run: cd apps/web && npm ci"
-}
-
-check_port_available() {
-  local service="$1"
-  local port
-  port="$(service_port "$service")"
-  local pid=""
-  if pid="$(service_pid_status "$service" 2>/dev/null)"; then
-    printf "%s already running via PID %s.\nUse make dev-status or make dev-down before starting again.\n" "$service" "$pid" >&2
-    exit 1
-  fi
-
-  local listeners
-  listeners="$(port_listener "$port")"
-  if [[ -n "$listeners" ]]; then
-    printf "Port %s is already in use, cannot start %s.\n%s\n" "$port" "$service" "$listeners" >&2
-    exit 1
-  fi
 }
 
 launch_detached() {
@@ -235,6 +264,186 @@ start_service() {
   printf "%s\n" "$pid" >"$pid_file"
 }
 
+service_health_code() {
+  local service="$1"
+  case "$service" in
+    core)
+      if http_ok "$CORE_URL/healthz" && http_ok "$CORE_URL/readyz"; then
+        printf "healthy"
+      elif http_ok "$CORE_URL/healthz"; then
+        printf "degraded"
+      else
+        printf "unhealthy"
+      fi
+      ;;
+    obs)
+      if http_ok "$OBS_URL/health"; then
+        printf "healthy"
+      else
+        printf "unhealthy"
+      fi
+      ;;
+    web)
+      if http_ok "$WEB_URL/api/core/healthz"; then
+        printf "healthy"
+      elif http_ok "$WEB_URL/"; then
+        printf "degraded"
+      else
+        printf "unhealthy"
+      fi
+      ;;
+    *)
+      printf "unknown"
+      ;;
+  esac
+}
+
+service_health_phrase() {
+  local service="$1"
+  case "$(service_health_code "$service")" in
+    healthy)
+      printf "healthy"
+      ;;
+    degraded)
+      case "$service" in
+        core) printf "process up, not ready" ;;
+        web) printf "process up, proxy not ready" ;;
+        *) printf "degraded" ;;
+      esac
+      ;;
+    unhealthy)
+      printf "unhealthy"
+      ;;
+    *)
+      printf "unknown"
+      ;;
+  esac
+}
+
+service_runtime_snapshot() {
+  local service="$1"
+  clear_stale_pid "$service"
+
+  local pid=""
+  local port
+  local listeners
+  local health
+
+  port="$(service_port "$service")"
+  health="$(service_health_code "$service")"
+
+  if pid="$(service_pid_status "$service" 2>/dev/null)"; then
+    if [[ "$health" == "healthy" ]]; then
+      printf "launcher|healthy|%s\n" "$pid"
+    elif [[ "$health" == "degraded" ]]; then
+      printf "launcher|degraded|%s\n" "$pid"
+    else
+      printf "launcher|unhealthy|%s\n" "$pid"
+    fi
+    return 0
+  fi
+
+  listeners="$(port_listener "$port")"
+  if [[ -n "$listeners" ]]; then
+    if [[ "$health" == "healthy" ]]; then
+      printf "unmanaged|healthy|-\n"
+    elif [[ "$health" == "degraded" ]]; then
+      printf "unmanaged|degraded|-\n"
+    else
+      printf "conflict|port-in-use|-\n"
+    fi
+    return 0
+  fi
+
+  printf "none|stopped|-\n"
+}
+
+wait_for_service_ready() {
+  local service="$1"
+  local timeout="${2:-}"
+  case "$service" in
+    core)
+      wait_for_http core "$CORE_URL/healthz" "${timeout:-30}"
+      wait_for_http core "$CORE_URL/readyz" "${timeout:-30}"
+      ;;
+    obs)
+      wait_for_http obs "$OBS_URL/health" "${timeout:-30}"
+      ;;
+    web)
+      wait_for_http web "$WEB_URL/api/core/healthz" "${timeout:-45}"
+      ;;
+    *)
+      printf "Unknown service: %s\n" "$service" >&2
+      return 1
+      ;;
+  esac
+}
+
+describe_port_conflict() {
+  local service="$1"
+  local port
+  port="$(service_port "$service")"
+  printf "%s cannot start because port %s is occupied by a non-StateLock process.\n" "$service" "$port" >&2
+  port_listener "$port" >&2
+}
+
+ensure_service_running() {
+  local service="$1"
+  local label="$2"
+  local snapshot owner health pid
+  ENSURE_SERVICE_ACTION="none"
+
+  snapshot="$(service_runtime_snapshot "$service")"
+  IFS='|' read -r owner health pid <<<"$snapshot"
+
+  case "$owner:$health" in
+    launcher:healthy)
+      ENSURE_SERVICE_ACTION="reused"
+      printf "%s already running and healthy.\n" "$label"
+      return 0
+      ;;
+    unmanaged:healthy)
+      ENSURE_SERVICE_ACTION="reused"
+      printf "%s already running and healthy on %s (not launcher-managed).\n" \
+        "$label" "$(service_url "$service")"
+      return 0
+      ;;
+    launcher:degraded)
+      ENSURE_SERVICE_ACTION="reused"
+      printf "%s already running and still settling; waiting for readiness...\n" "$label"
+      wait_for_service_ready "$service" 15
+      return 0
+      ;;
+    unmanaged:degraded)
+      ENSURE_SERVICE_ACTION="reused"
+      printf "%s is already serving on %s and looks like StateLock; waiting for readiness...\n" \
+        "$label" "$(service_url "$service")"
+      wait_for_service_ready "$service" 15
+      return 0
+      ;;
+    launcher:unhealthy)
+      ENSURE_SERVICE_ACTION="restarted"
+      printf "%s is launcher-managed but unhealthy; restarting it...\n" "$label"
+      stop_service "$service" >/dev/null
+      ;;
+    conflict:port-in-use)
+      describe_port_conflict "$service"
+      return 1
+      ;;
+    none:stopped)
+      ENSURE_SERVICE_ACTION="started"
+      ;;
+    *)
+      printf "%s is in an unexpected state (%s).\n" "$label" "$snapshot" >&2
+      return 1
+      ;;
+  esac
+
+  printf "Starting %s on %s...\n" "$label" "$(service_url "$service")"
+  start_service "$service"
+  wait_for_service_ready "$service"
+}
+
 stop_service() {
   local service="$1"
   local pid_file
@@ -243,13 +452,35 @@ stop_service() {
   pid="$(read_pid "$pid_file")"
 
   if [[ -z "${pid:-}" ]]; then
-    printf "%s: not running (no pid file)\n" "$service"
+    local snapshot owner health _
+    snapshot="$(service_runtime_snapshot "$service")"
+    IFS='|' read -r owner health _ <<<"$snapshot"
+    case "$owner:$health" in
+      unmanaged:healthy|unmanaged:degraded)
+        printf "%s: running on %s but not launcher-managed; leaving it alone\n" \
+          "$service" "$(service_url "$service")"
+        ;;
+      conflict:port-in-use)
+        printf "%s: port %s is occupied by a non-StateLock process; nothing stopped\n" \
+          "$service" "$(service_port "$service")"
+        ;;
+      *)
+        printf "%s: not running (no pid file)\n" "$service"
+        ;;
+    esac
     return 0
   fi
 
   if ! pid_is_running "$pid"; then
     rm -f "$pid_file"
     printf "%s: stale pid removed (%s)\n" "$service" "$pid"
+    return 0
+  fi
+
+  if ! pid_matches_service "$service" "$pid"; then
+    rm -f "$pid_file"
+    printf "%s: pid file removed without killing pid %s (process no longer matched %s)\n" \
+      "$service" "$pid" "$service"
     return 0
   fi
 
@@ -303,51 +534,111 @@ wait_for_http() {
 
 health_summary() {
   local service="$1"
-  case "$service" in
-    core)
-      if http_ok "$CORE_URL/healthz" && http_ok "$CORE_URL/readyz"; then
-        printf "healthy"
-      elif http_ok "$CORE_URL/healthz"; then
-        printf "process up, not ready"
-      else
-        printf "unhealthy"
-      fi
+  service_health_phrase "$service"
+}
+
+stack_overall_status() {
+  local services=(core obs web)
+  local healthy_count=0
+  local degraded_count=0
+  local conflict_count=0
+  local stopped_count=0
+  local service snapshot owner health pid
+
+  for service in "${services[@]}"; do
+    snapshot="$(service_runtime_snapshot "$service")"
+    IFS='|' read -r owner health pid <<<"$snapshot"
+    case "$owner:$health" in
+      launcher:healthy|unmanaged:healthy) healthy_count=$((healthy_count + 1)) ;;
+      launcher:degraded|unmanaged:degraded) degraded_count=$((degraded_count + 1)) ;;
+      conflict:port-in-use) conflict_count=$((conflict_count + 1)) ;;
+      none:stopped) stopped_count=$((stopped_count + 1)) ;;
+      *) degraded_count=$((degraded_count + 1)) ;;
+    esac
+  done
+
+  if [[ "$healthy_count" -eq 3 ]]; then
+    printf "healthy"
+  elif [[ "$conflict_count" -gt 0 ]]; then
+    printf "blocked"
+  elif [[ "$stopped_count" -eq 0 && "$degraded_count" -gt 0 && $((healthy_count + degraded_count)) -eq 3 ]]; then
+    printf "degraded"
+  elif [[ "$stopped_count" -eq 3 ]]; then
+    printf "stopped"
+  elif [[ "$healthy_count" -gt 0 || "$degraded_count" -gt 0 ]]; then
+    printf "partial"
+  else
+    printf "mixed"
+  fi
+}
+
+service_display_name() {
+  case "$1" in
+    core) printf "Core" ;;
+    obs) printf "Observability" ;;
+    web) printf "UI" ;;
+    *) printf "%s" "$1" ;;
+  esac
+}
+
+service_status_label() {
+  local service="$1"
+  local snapshot owner health pid
+  snapshot="$(service_runtime_snapshot "$service")"
+  IFS='|' read -r owner health pid <<<"$snapshot"
+
+  case "$owner:$health" in
+    launcher:healthy) printf "healthy" ;;
+    launcher:degraded) printf "degraded" ;;
+    launcher:unhealthy) printf "unhealthy" ;;
+    unmanaged:healthy) printf "healthy (external)" ;;
+    unmanaged:degraded) printf "degraded (external)" ;;
+    conflict:port-in-use) printf "blocked" ;;
+    none:stopped) printf "down" ;;
+    *) printf "unknown" ;;
+  esac
+}
+
+service_status_detail() {
+  local service="$1"
+  local snapshot owner health pid
+  snapshot="$(service_runtime_snapshot "$service")"
+  IFS='|' read -r owner health pid <<<"$snapshot"
+
+  case "$owner:$health" in
+    launcher:healthy)
+      return 0
       ;;
-    obs)
-      if http_ok "$OBS_URL/health"; then
-        printf "healthy"
-      else
-        printf "unhealthy"
-      fi
+    launcher:degraded|launcher:unhealthy)
+      printf "launcher-managed, pid=%s, log=%s" "$pid" "$(service_log_file "$service")"
       ;;
-    web)
-      if http_ok "$WEB_URL/api/core/healthz"; then
-        printf "healthy"
-      elif http_ok "$WEB_URL/"; then
-        printf "process up, proxy not ready"
-      else
-        printf "unhealthy"
-      fi
+    unmanaged:healthy|unmanaged:degraded)
+      printf "running outside the launcher on the expected port"
       ;;
-    *)
-      printf "unknown"
+    conflict:port-in-use)
+      printf "port %s is occupied by a non-StateLock process" "$(service_port "$service")"
+      ;;
+    none:stopped)
+      return 0
       ;;
   esac
 }
 
-print_status_line() {
+print_status_block() {
   local service="$1"
-  local url log_file pid listeners
+  local url detail
+
+  printf "%s: %s\n" \
+    "$(service_display_name "$service")" \
+    "$(service_status_label "$service")"
+
   url="$(service_url "$service")"
-  log_file="$(service_log_file "$service")"
-  if pid="$(service_pid_status "$service" 2>/dev/null)"; then
-    printf "%-5s running  pid=%-8s health=%-20s url=%s log=%s\n" \
-      "$service" "$pid" "$(health_summary "$service")" "$url" "$log_file"
-  elif listeners="$(port_listener "$(service_port "$service")")" && [[ -n "$listeners" ]]; then
-    printf "%-5s external pid=%-8s health=%-20s url=%s log=%s\n" \
-      "$service" "-" "port in use" "$url" "$log_file"
-  else
-    printf "%-5s stopped  pid=%-8s health=%-20s url=%s log=%s\n" \
-      "$service" "-" "not running" "$url" "$log_file"
+  if [[ -n "$url" ]]; then
+    printf "  %s\n" "$url"
+  fi
+
+  detail="$(service_status_detail "$service")" || true
+  if [[ -n "${detail:-}" ]]; then
+    printf "  %s\n" "$detail"
   fi
 }


### PR DESCRIPTION
## Summary
- make `make dev-up` idempotent so startup reconciles current service state instead of failing on “already running”
- repair stale PID files safely and recover partial local stacks without tearing down healthy services
- add `make dev-open` and `make dev-restart` wrappers to align the launcher UX around ensure/open and restart flows
- make `make dev-status` render a human-readable stack summary with overall state, per-service health, and service URLs

## What Changed
- `make dev-up` now checks actual service state and health before deciding whether to start, reuse, wait, or restart a service
- startup now treats healthy already-running services as success instead of as a hard failure
- stale PID files are repaired when the PID is gone or no longer matches the expected StateLock process
- partial-stack recovery is supported: missing services are started while healthy services are reused
- `make dev-open` was added to ensure the stack is up before opening the UI
- `make dev-restart` was added as a dedicated restart wrapper
- `make dev-status` now shows:
  - overall state
  - per-service health
  - service URLs
- unmanaged, conflict, and degraded ownership details only appear when relevant

## Verification
- start from stopped: passed
- start when already running: passed
- stop: passed
- restart: passed
- stale PID handling: passed
- partial-stack handling: passed
- status output for healthy and partial cases: passed

## Notes
- Core vs Observability boundaries are unchanged; this is only launcher/lifecycle UX work
- the new status output stays compact by default and only surfaces ownership/conflict detail when it adds signal
