### PR TITLE
[codex] Normalize markdown formatting in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,10 @@ test_chroma_db/
 site/
 docs/domain-operations.md
 docs/website-routing.md
-docs/codex-rehydration-prompt.md
+docs/rehydration-repo-snapshot.md
+docs/rehydration-template.md
+docs/session-delta.md
+
 
 # Runtime env
 .env

--- a/docs/architecture-continuity-layer.md
+++ b/docs/architecture-continuity-layer.md
@@ -150,8 +150,8 @@ Practical interpretation:
 That makes the continuity layer:
 
 1. durable memory in Core,
-2. conversation-state and context assembly in Observability,
-3. adapter integration at the edge.
+1. conversation-state and context assembly in Observability,
+1. adapter integration at the edge.
 
 This is already how the repo behaves in practice.
 
@@ -225,11 +225,11 @@ Evidence:
 Import architecture should initially mean:
 
 1. external export file
-2. parser/normalizer
-3. normalized conversation bundle
-4. Observability import
-5. optional distillation into Observability memory
-6. optional later projection into Core memory blocks
+1. parser/normalizer
+1. normalized conversation bundle
+1. Observability import
+1. optional distillation into Observability memory
+1. optional later projection into Core memory blocks
 
 ### Raw archive store classification
 
@@ -295,9 +295,9 @@ Promotion should be **incremental**, preserving subsystem coherence.
 That means:
 
 1. keep conversation-centric capabilities isolated under `experimental/observability/`
-2. stabilize interfaces and schemas first
-3. promote cohesive modules later into a future `app/observability/` namespace
-4. do **not** scatter context/import/distillation concerns across root `app/` prematurely
+1. stabilize interfaces and schemas first
+1. promote cohesive modules later into a future `app/observability/` namespace
+1. do **not** scatter context/import/distillation concerns across root `app/` prematurely
 
 Evidence:
 
@@ -392,7 +392,7 @@ Two follow-on design tracks are consistent with this architecture and should rem
 Observability-led rather than Core-led:
 
 1. **Experience / procedural memory extraction**
-2. **Memory stratification across raw, working, semantic, episodic, and procedural layers**
+1. **Memory stratification across raw, working, semantic, episodic, and procedural layers**
 
 These are documented in:
 

--- a/docs/architecture-memory-graph.md
+++ b/docs/architecture-memory-graph.md
@@ -159,9 +159,9 @@ Recommended hybrid model:
 
 1. **Vector recall**
    - find semantically relevant blocks or entries
-2. **Graph expansion**
+1. **Graph expansion**
    - follow important links such as provenance, contradiction, episode, applies-to, or supersession
-3. **Selection/promotion logic**
+1. **Selection/promotion logic**
    - decide what enters working context, what is reinforced, and what should project into Core
 
 Repo grounding:
@@ -489,26 +489,26 @@ Practical interpretation:
 
 1. **Document the graph role**
    - this document
-2. **Keep graph ownership in Observability**
+1. **Keep graph ownership in Observability**
    - do not widen Core
-3. **Normalize existing implicit links**
+1. **Normalize existing implicit links**
    - provenance, contradictions, semantic neighbors, source refs
-4. **Add minimal node/edge schema**
+1. **Add minimal node/edge schema**
    - enough for provenance and relationship neighborhoods
-5. **Connect graph edges to PromotionArtifact / PromotionDecision / ProjectionRecord**
+1. **Connect graph edges to PromotionArtifact / PromotionDecision / ProjectionRecord**
    - only after promotion schemas stabilize
-6. **Use graph for better context expansion and promotion analysis**
+1. **Use graph for better context expansion and promotion analysis**
    - before considering any graph-native runtime features
-7. **Evaluate whether Core needs any selective read-through later**
+1. **Evaluate whether Core needs any selective read-through later**
    - default answer should remain “probably not”
 
 ## 15. Open Questions
 
 1. Should the first graph schema model only Observability-native nodes, with Core blocks represented only through `ProjectionRecord`, or should Core blocks become direct node refs from the start?
-2. Should graph edges be explicit first-class rows, or should the first version normalize only the existing span/memory link fields into a common read model?
-3. Which entity nodes are worth first-class promotion earliest: user, agent, project, tool, or decision?
-4. Should episodic clusters be explicit graph nodes, or remain inferred from conversation/thread neighborhoods at first?
-5. When contradiction exists between semantic/procedural memories, should the graph store both the contradiction edge and the supersession edge, or only one plus status?
+1. Should graph edges be explicit first-class rows, or should the first version normalize only the existing span/memory link fields into a common read model?
+1. Which entity nodes are worth first-class promotion earliest: user, agent, project, tool, or decision?
+1. Should episodic clusters be explicit graph nodes, or remain inferred from conversation/thread neighborhoods at first?
+1. When contradiction exists between semantic/procedural memories, should the graph store both the contradiction edge and the supersession edge, or only one plus status?
 
 ## Cross-Reference
 

--- a/docs/architecture-memory-policy-profiles.md
+++ b/docs/architecture-memory-policy-profiles.md
@@ -423,11 +423,11 @@ That preserves the Core vs Observability split.
 Recommended early configurable items:
 
 1. `max_context_tokens`
-2. promotion aggressiveness level
-3. graph/provenance expansion depth
-4. telemetry retention level
-5. review strictness level
-6. cleanup/consolidation cadence
+1. promotion aggressiveness level
+1. graph/provenance expansion depth
+1. telemetry retention level
+1. review strictness level
+1. cleanup/consolidation cadence
 
 Why these first:
 
@@ -445,24 +445,24 @@ Avoid early overexposure of:
 
 1. **Document profile model first**
    - this document
-2. **Define 3-5 named presets**
+1. **Define 3-5 named presets**
    - no giant knob matrix
-3. **Attach presets to Observability continuity behavior**
+1. **Attach presets to Observability continuity behavior**
    - working-context build, promotion, review, retention
-4. **Add explicit logging of profile-driven decisions**
+1. **Add explicit logging of profile-driven decisions**
    - preserve transparency
-5. **Only then add more advanced cleanup/decay logic**
+1. **Only then add more advanced cleanup/decay logic**
    - after reinforcement/deprecation flows stabilize
-6. **Keep Core changes minimal**
+1. **Keep Core changes minimal**
    - ideally none beyond eventual consumption of projected semantic outputs
 
 ## 12. Open Questions
 
 1. Should profiles be global, per conversation, per session, or all three?
-2. Which dimensions belong in the user-visible preset vs internal tuning values?
-3. Should `Project-Focused` be a standalone preset or a scope overlay on top of `Balanced` / `Deep Continuity`?
-4. When privacy and continuity goals conflict, should the profile enforce hard caps or only stronger review thresholds?
-5. Should introspection/cleanup run opportunistically after active sessions, or on an explicit maintenance pass only?
+1. Which dimensions belong in the user-visible preset vs internal tuning values?
+1. Should `Project-Focused` be a standalone preset or a scope overlay on top of `Balanced` / `Deep Continuity`?
+1. When privacy and continuity goals conflict, should the profile enforce hard caps or only stronger review thresholds?
+1. Should introspection/cleanup run opportunistically after active sessions, or on an explicit maintenance pass only?
 
 ## Cross-Reference
 

--- a/docs/architecture-memory-stratification.md
+++ b/docs/architecture-memory-stratification.md
@@ -5,7 +5,7 @@
 The proposed extension is **architecturally sound**, with two important clarifications:
 
 1. The **Experience Layer** fits naturally under `experimental/observability/`, not Core.
-2. **Memory stratification** is a strong conceptual model for StateLock, but several layers are still conceptual or only partially represented in the repo today.
+1. **Memory stratification** is a strong conceptual model for StateLock, but several layers are still conceptual or only partially represented in the repo today.
 
 The repo already supports the underlying shape:
 
@@ -309,12 +309,12 @@ The currently bound conversation LLM can help propose interpretations, but it sh
 Why:
 
 1. The runtime LLM is optimized for answering the current prompt, not for long-horizon storage decisions.
-2. The repo already uses deterministic and inspectable logic in key places:
+1. The repo already uses deterministic and inspectable logic in key places:
    - save triggers in [`app/services/automation_policy.py`](../app/services/automation_policy.py#L31)
    - working-context assembly in [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py#L135)
    - telemetry metrics in [`experimental/observability/app/services/telemetry_service.py`](../experimental/observability/app/services/telemetry_service.py#L45)
    - governance remediation in [`experimental/observability/app/governance/actions.py`](../experimental/observability/app/governance/actions.py#L47)
-3. Provenance and traceability matter. A memory decision should be auditable against turns, spans, telemetry, and policies.
+1. Provenance and traceability matter. A memory decision should be auditable against turns, spans, telemetry, and policies.
 
 So the correct architectural principle is:
 
@@ -328,13 +328,13 @@ The repo-aligned decision pipeline is:
 1. **Deterministic rules**
    - obvious triggers, bans, trust boundaries, explicit commands, policy rules
    - existing precedent: save trigger patterns in [`app/services/automation_policy.py`](../app/services/automation_policy.py#L9)
-2. **Cheap classifier / heuristic stage**
+1. **Cheap classifier / heuristic stage**
    - low-cost scoring for semantic vs episodic vs procedural tendency
    - current precedent: thread inference, span scoring, recency/trust heuristics in [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py#L58)
-3. **Stronger distillation pass**
+1. **Stronger distillation pass**
    - higher-cost structured extraction and contradiction/redundancy checks
    - current precedent: distillation critic pass described in [`experimental/observability/statelock-v2-mvp.yaml`](../experimental/observability/statelock-v2-mvp.yaml#L330)
-4. **Optional human confirmation for major promotions**
+1. **Optional human confirmation for major promotions**
    - use for irreversible or high-impact promotions such as durable architectural policies, user identity changes, or cross-project workflow canon
 
 This preserves safety and auditability without blocking normal operation.

--- a/docs/architecture-promotion-engine.md
+++ b/docs/architecture-promotion-engine.md
@@ -58,7 +58,7 @@ Without a Promotion Engine, StateLock risks collapsing into one of two bad modes
 
 1. **Everything becomes memory**
    - low-trust or temporary artifacts pollute durable retrieval
-2. **Nothing becomes memory**
+1. **Nothing becomes memory**
    - continuity remains trapped in transient traces and never becomes reusable
 
 The repo already hints at the right balance:
@@ -99,11 +99,11 @@ Less preferred:
 Recommended pipeline:
 
 1. **Artifact normalization**
-2. **Artifact classification**
-3. **Artifact scoring**
-4. **Rule evaluation**
-5. **Promotion decision / state transition**
-6. **Reinforcement / deprecation / retirement over time**
+1. **Artifact classification**
+1. **Artifact scoring**
+1. **Rule evaluation**
+1. **Promotion decision / state transition**
+1. **Reinforcement / deprecation / retirement over time**
 
 ### 1. Artifact normalization
 
@@ -308,13 +308,13 @@ Recommended protections:
 
 1. **Provenance requirement**
    - promoted artifacts must point back to source turns/spans/import records
-2. **Contradiction-aware promotion**
+1. **Contradiction-aware promotion**
    - contradiction with existing durable memory lowers promotion confidence
-3. **Quarantine path**
+1. **Quarantine path**
    - suspicious artifacts should be held or quarantined instead of promoted
-4. **Policy-risk gating**
+1. **Policy-risk gating**
    - policy/constraints-like artifacts should require deterministic rules or confirmation
-5. **No sole LLM authority**
+1. **No sole LLM authority**
    - the active conversation model can propose candidates, but not unilaterally promote them
 
 Repo grounding:
@@ -410,15 +410,15 @@ Possible routing path:
 
 1. **Raw archive**
    - captured as conversation turns/imported discussion artifacts in Observability
-2. **Working memory**
+1. **Working memory**
    - appears in the current working context while architectural discussion is active
-3. **Episodic memory**
+1. **Episodic memory**
    - stored as a notable architecture decision episode tied to a specific discussion/run
-4. **Durable semantic memory**
+1. **Durable semantic memory**
    - promoted only if repeated and stable enough to become a durable repo fact or project principle
-5. **Policy / constraints**
+1. **Policy / constraints**
    - if it becomes a project-wide architectural constraint, it may be elevated into policy/constraints documentation rather than ordinary memory
-6. **Procedural / experience lesson**
+1. **Procedural / experience lesson**
    - if repeated work shows that keeping Core stable and putting conversation features in Observability consistently reduces churn, that becomes an experience/procedural lesson
 
 Why this example matters:
@@ -457,15 +457,15 @@ Why this example matters:
 
 1. **Document the Promotion Engine**
    - terminology, states, scoring, ownership boundaries
-2. **Define normalized artifact and provenance interfaces**
+1. **Define normalized artifact and provenance interfaces**
    - stay in Observability
-3. **Add candidate/promotion metadata to Observability models**
+1. **Add candidate/promotion metadata to Observability models**
    - only after the design stabilizes
-4. **Wire reinforcement/deprecation signals**
+1. **Wire reinforcement/deprecation signals**
    - use existing telemetry/governance/eval counters
-5. **Introduce explicit projection rules into Core**
+1. **Introduce explicit projection rules into Core**
    - only for durable semantic memory
-6. **Add human-gated paths for policy/high-risk promotion**
+1. **Add human-gated paths for policy/high-risk promotion**
    - later phase
 
 This sequence keeps changes incremental and preserves the current Core vs Observability split.

--- a/docs/architecture-promotion-schemas.md
+++ b/docs/architecture-promotion-schemas.md
@@ -386,7 +386,7 @@ It should not be raw trace records.
 It should be:
 
 1. a **Core-compatible semantic projection payload**, plus
-2. an **Observability-side trace record** proving where it came from and why it was promoted.
+1. an **Observability-side trace record** proving where it came from and why it was promoted.
 
 That is exactly what `ProjectionRecord` captures.
 
@@ -566,9 +566,9 @@ That keeps the first schema implementation-friendly.
 Recommended minimum schema set for the first implementation phase:
 
 1. `PromotionArtifact`
-2. `PromotionEvidence`
-3. `PromotionDecision`
-4. `ProjectionRecord`
+1. `PromotionEvidence`
+1. `PromotionDecision`
+1. `ProjectionRecord`
 
 `PromotionStatus` can be implemented either:
 
@@ -588,25 +588,25 @@ That is the minimum needed for auditable promotion.
 
 1. **Document the schema boundary first**
    - this document
-2. **Add Observability-side conceptual models**
+1. **Add Observability-side conceptual models**
    - artifact, evidence, decision, projection
-3. **Keep Core unchanged initially**
+1. **Keep Core unchanged initially**
    - reuse `MemoryUpsert` payload shape
-4. **Add projection write path**
+1. **Add projection write path**
    - Observability emits reduced semantic block into Core
-5. **Add reinforcement/deprecation hooks**
+1. **Add reinforcement/deprecation hooks**
    - driven by telemetry/governance outcomes
-6. **Only then consider richer review/supersession UI**
+1. **Only then consider richer review/supersession UI**
 
 This sequence keeps Core stable and pushes experimentation where the repo already expects it: Observability.
 
 ## 15. Open Questions
 
 1. Should `PromotionArtifact` be a durable DB model or a normalized transient pipeline object first?
-2. Should `PromotionEvidence` be one record per source signal, or a compact aggregate per decision?
-3. What deterministic `external_id` strategy should be used for projected Core blocks?
-4. When an existing Core block is superseded, should Core memory content be updated in place or appended as a new block with lineage kept only in Observability?
-5. Should some high-confidence explicit user constraints bypass the normal semantic projection path and land in a separate policy registry instead of Core memory?
+1. Should `PromotionEvidence` be one record per source signal, or a compact aggregate per decision?
+1. What deterministic `external_id` strategy should be used for projected Core blocks?
+1. When an existing Core block is superseded, should Core memory content be updated in place or appended as a new block with lineage kept only in Observability?
+1. Should some high-confidence explicit user constraints bypass the normal semantic projection path and land in a separate policy registry instead of Core memory?
 
 ## Cross-Reference
 

--- a/docs/architecture-sanity-check.md
+++ b/docs/architecture-sanity-check.md
@@ -111,16 +111,17 @@ Evidence:
 
 - [`docs/run-with-local-first-stack.md`](../docs/run-with-local-first-stack.md) lines 36-43:
   > Use a tool wrapper that calls StateLock:
+  >
   > - `memory.save`
   > - `memory.query`
   > - `memory.clear_session`
 - [`docs/run-with-local-first-stack.md`](../docs/run-with-local-first-stack.md) lines 66-75 show the current flow:
   1. Agent receives message
-  2. derive session id
-  3. call `memory.query`
-  4. build prompt
-  5. call LiteLLM
-  6. save facts with `memory.save`
+  1. derive session id
+  1. call `memory.query`
+  1. build prompt
+  1. call LiteLLM
+  1. save facts with `memory.save`
 - [`examples/openclaw-tooling/README.md`](../examples/openclaw-tooling/README.md) lines 3-11 defines the tool surface:
   - `memory.save`
   - `memory.query`
@@ -311,9 +312,9 @@ For OpenClaw, the lowest-risk first-class surfaces are probably:
    - `POST /memories/query`
    - `POST /memories/query-hybrid`
    - session snapshot/restore
-2. **Optionally reuse Observability working-context API experimentally**
+1. **Optionally reuse Observability working-context API experimentally**
    - `POST /v2/conversations/{conversation_id}/working_context`
-3. **Do not add `/gateway/*` yet**
+1. **Do not add `/gateway/*` yet**
 
 ### Endpoint naming fit
 
@@ -349,9 +350,9 @@ Evidence:
 ### Recommended first scope
 
 1. Define a **normalized conversation bundle schema** compatible with Observability import/export.
-2. Add importer/parser modules under **Observability** or a dedicated ingestion package adjacent to it.
-3. Keep raw archive storage additive and explicit.
-4. Only later decide whether distilled outputs should be projected into Core memory blocks.
+1. Add importer/parser modules under **Observability** or a dedicated ingestion package adjacent to it.
+1. Keep raw archive storage additive and explicit.
+1. Only later decide whether distilled outputs should be projected into Core memory blocks.
 
 ### Should raw archive store + distilled memory graph + context builder be treated as…
 
@@ -491,20 +492,20 @@ This is compatible with current Observability distillation, which already record
 1. **Docs/ADR first**
    - revise the proposed architecture so it respects the Core/Observability split
    - explicitly classify gateway, import, and crypto as separate concerns
-2. **Observability import schema**
+1. **Observability import schema**
    - formalize normalized conversation bundle format
    - keep this under `experimental/observability/`
-3. **Example importers**
+1. **Example importers**
    - implement one or two importers as experimental tooling
    - likely ChatGPT export + markdown first
-4. **Observability provenance/distillation linkage**
+1. **Observability provenance/distillation linkage**
    - make imported turns/spans/distilled memory relationships explicit
-5. **OpenClaw adapter examples**
+1. **OpenClaw adapter examples**
    - extend `examples/openclaw-tooling/`
    - optionally add example use of Observability working-context APIs
-6. **Evaluate promotion**
+1. **Evaluate promotion**
    - only after interfaces settle, decide whether to promote import/distillation pieces out of `experimental/`
-7. **Deferred security layer**
+1. **Deferred security layer**
    - design encrypted bundles / signing only after archive/export formats stabilize
 
 ## 11. File/Module Placement Recommendations
@@ -564,14 +565,13 @@ Good fit for:
 ## 12. Outstanding Questions or Decision Points
 
 1. Should imported conversation data remain purely Observability-owned, or should there be a later projection path into Core memory blocks?
-2. Is the long-term goal still to keep StateLock out of model routing entirely, or is there a deliberate future plan to make it a gateway/service mesh component?
-3. If chat importers are added, is the first desired output:
+1. Is the long-term goal still to keep StateLock out of model routing entirely, or is there a deliberate future plan to make it a gateway/service mesh component?
+1. If chat importers are added, is the first desired output:
    - replay/debugging,
    - memory distillation,
    - or both?
-4. Does raw archive storage need to be a filesystem tree, or can the first version rely on versioned portable bundles plus DB-backed normalized records?
-5. If crypto is added later, what is the first protected boundary:
+1. Does raw archive storage need to be a filesystem tree, or can the first version rely on versioned portable bundles plus DB-backed normalized records?
+1. If crypto is added later, what is the first protected boundary:
    - export bundle,
    - raw archive,
    - or full local DB?
-

--- a/docs/local-stack-panic-recovery.md
+++ b/docs/local-stack-panic-recovery.md
@@ -1,131 +1,143 @@
-LOCAL STACK PANIC RECOVERY CHECKLIST
+# Local Stack Panic Recovery Checklist
+
 Do these in order. Do not skip steps.
 
-⸻
-
-STEP 1 — WHAT IS ACTUALLY BROKEN?
+## Step 1: What Is Actually Broken?
 
 Ask yourself:
 
 Are you:
-	•	Just chatting in the browser?
-	•	Running StateLock / client.ts?
-	•	Getting a 500 error?
-	•	Getting connection refused?
+
+- Just chatting in the browser?
+- Running StateLock / `client.ts`?
+- Getting a 500 error?
+- Getting connection refused?
 
 Different problems = different fixes.
 
-⸻
-
-STEP 2 — CHECK OLLAMA
+## Step 2: Check Ollama
 
 Check if Ollama is alive:
 
+```bash
 lsof -i :11434
+```
 
 If nothing shows:
+
+```bash
 ollama serve
+```
 
 Test Ollama directly:
 
-curl http://localhost:11434/api/generate -d ‘{“model”:“qwen2.5:7b-instruct”,“prompt”:“say ok”,“stream”:false}’
+```bash
+curl http://localhost:11434/api/generate -d '{"model":"qwen2.5:7b-instruct","prompt":"say ok","stream":false}'
+```
 
-If that works → Ollama is fine.
+If that works -> Ollama is fine.
 
 Do NOT reinstall Ollama.
 
-⸻
-
-STEP 3 — CHECK LITELLM
+## Step 3: Check LiteLLM
 
 Check if running:
 
+```bash
 lsof -i :4000
+```
 
 If nothing shows:
-~/venvs/litellm/bin/litellm –config ~/litellm.yaml –port 4000
+
+```bash
+~/venvs/litellm/bin/litellm --config ~/litellm.yaml --port 4000
+```
 
 If multiple instances:
+
+```bash
 pkill -f litellm
+```
+
 Start again clean.
 
-⸻
+## Step 4: Verify Models
 
-STEP 4 — VERIFY MODELS
-
+```bash
 curl -s http://localhost:4000/v1/models
+```
 
 If you see:
-chat_default
-deep_default
-code_default
-cloud_code
-cloud_reason
+
+- `chat_default`
+- `deep_default`
+- `code_default`
+- `cloud_code`
+- `cloud_reason`
 
 LiteLLM config is loading correctly.
 
-If not → check ~/litellm.yaml exists.
+If not -> check `~/litellm.yaml` exists.
 
-⸻
+## Step 5: Test Simple Call
 
-STEP 5 — TEST SIMPLE CALL
+```bash
+curl -s http://localhost:4000/v1/chat/completions -H "Content-Type: application/json" -d '{"model":"chat_default","messages":[{"role":"user","content":"say ok"}],"max_tokens":10}'
+```
 
-curl -s http://localhost:4000/v1/chat/completions -H “Content-Type: application/json” -d ‘{“model”:“chat_default”,“messages”:[{“role”:“user”,“content”:“say ok”}],“max_tokens”:10}’
-
-If that works → routing works.
+If that works -> routing works.
 
 If that fails:
-	•	Read the error carefully.
-	•	It is almost always auth or model name mismatch.
-	•	Do not reinstall Python.
 
-⸻
+- Read the error carefully.
+- It is almost always auth or model name mismatch.
+- Do not reinstall Python.
 
-STEP 6 — CLOUD ERROR?
+## Step 6: Cloud Error?
 
 If you see:
-AuthenticationError
-or OPENAI_API_KEY errors
+
+- `AuthenticationError`
+- or `OPENAI_API_KEY` errors
 
 Fix:
-echo ‘export OPENAI_API_KEY=“YOUR_KEY”’ >> ~/.zshrc
+
+```bash
+echo 'export OPENAI_API_KEY="YOUR_KEY"' >> ~/.zshrc
 source ~/.zshrc
+```
 
 Do NOT touch Ollama.
 
-⸻
-
-STEP 7 — UI CONFUSION?
+## Step 7: UI Confusion?
 
 Remember:
 
-Port 3000 = Ollama UI = local only
-Port 4000 = LiteLLM = router
+- Port `3000` = Ollama UI = local only
+- Port `4000` = LiteLLM = router
 
 The UI does NOT use LiteLLM.
 
-⸻
-
-NEVER DO THIS DURING PANIC
+## Never Do This During Panic
 
 Do NOT:
-	•	Delete venv
-	•	Reinstall Python
-	•	Reinstall Ollama
-	•	Randomly upgrade pip
-	•	Install random dependencies
-	•	Change model names blindly
 
-⸻
+- Delete venv
+- Reinstall Python
+- Reinstall Ollama
+- Randomly upgrade pip
+- Install random dependencies
+- Change model names blindly
 
-IF STILL BROKEN
+## If Still Broken
 
 Run these and inspect:
 
+```bash
 lsof -i :11434
 lsof -i :4000
 cat ~/litellm.yaml
 which litellm
+```
 
 Then debug calmly.
-

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -63,9 +63,9 @@ python scripts/session_snapshot_cli.py import \
 ## Upgrade
 
 1. Pull latest code.
-2. Review `CHANGELOG.md` for interface/env changes.
-3. If `apps/web` is present, run `make web-check`.
-4. Rebuild/restart:
+1. Review `CHANGELOG.md` for interface/env changes.
+1. If `apps/web` is present, run `make web-check`.
+1. Rebuild/restart:
 
 ```bash
 make down-prod
@@ -82,7 +82,7 @@ curl -sS http://127.0.0.1:8000/readyz
 ## Rollback
 
 1. Checkout previous git tag/commit.
-2. Restart with previous image/config:
+1. Restart with previous image/config:
 
 ```bash
 make down-prod

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -3,26 +3,26 @@
 ## Pre-release
 
 1. Ensure branch is up to date with `main`.
-2. Run `make lint` and `make test`.
-3. Run `make web-check` when `apps/web` is present.
-4. Verify `.env.example` matches current required env vars.
-5. Confirm docs updates for any public interface changes.
-6. Update `CHANGELOG.md` under `[Unreleased]`.
+1. Run `make lint` and `make test`.
+1. Run `make web-check` when `apps/web` is present.
+1. Verify `.env.example` matches current required env vars.
+1. Confirm docs updates for any public interface changes.
+1. Update `CHANGELOG.md` under `[Unreleased]`.
 
 ## Version cut
 
 1. Bump `API_VERSION` in `.env.example` and deployment env if needed.
-2. Move `[Unreleased]` notes to a dated version section in `CHANGELOG.md`.
-3. Tag release:
+1. Move `[Unreleased]` notes to a dated version section in `CHANGELOG.md`.
+1. Tag release:
    - `git tag vX.Y.Z`
    - `git push origin vX.Y.Z`
 
 ## Post-release
 
 1. Publish GitHub release notes from `CHANGELOG.md`.
-2. Smoke test:
+1. Smoke test:
    - `GET /healthz`
    - `GET /readyz`
    - one `memory.query` + one `memory.save` flow
-3. Smoke test the unified web UI when `apps/web` ships in the release.
-4. Archive exported snapshot fixture for rollback testing.
+1. Smoke test the unified web UI when `apps/web` ships in the release.
+1. Archive exported snapshot fixture for rollback testing.

--- a/docs/run-with-local-first-stack.md
+++ b/docs/run-with-local-first-stack.md
@@ -75,12 +75,12 @@ Example:
 ## 4) Example flow
 
 1. Agent receives message.
-2. Derive session id: `{channel}:{thread_or_chat}:{user_or_agent}`.
-3. Call `memory.query` for session context.
-3. Build prompt with retrieved memories.
-4. Call LiteLLM model alias.
-5. Emit confidence hint (`confidence_low`) from model output.
-6. Save durable facts with `memory.save` based on policy triggers.
+1. Derive session id: `{channel}:{thread_or_chat}:{user_or_agent}`.
+1. Call `memory.query` for session context.
+1. Build prompt with retrieved memories.
+1. Call LiteLLM model alias.
+1. Emit confidence hint (`confidence_low`) from model output.
+1. Save durable facts with `memory.save` based on policy triggers.
 
 Automation contract:
 

--- a/docs/statelock-cognitive-architecture.md
+++ b/docs/statelock-cognitive-architecture.md
@@ -288,7 +288,7 @@ Repo evidence:
 There are two memory notions in the repo:
 
 1. **Core memory blocks** in Chroma
-2. **Observability memory entries** derived from conversations
+1. **Observability memory entries** derived from conversations
 
 That duality is why the continuity-layer framing matters.
 
@@ -392,7 +392,7 @@ That keeps the repo modular and lets more experimental reasoning-support feature
 This architecture is strong because it avoids two common failures:
 
 1. putting too much experimental reasoning logic into the stable runtime
-2. treating memory as only vector retrieval instead of continuity management
+1. treating memory as only vector retrieval instead of continuity management
 
 The repo already has the beginnings of a stronger pattern:
 
@@ -452,4 +452,3 @@ OpenClaw / agents / tools = integration edge
 Reasoning/model invocation stays outside StateLock.
 Continuity emerges from Core durability + Observability context intelligence.
 ```
-


### PR DESCRIPTION
## Summary
This PR normalizes Markdown formatting across the current `docs/` set without changing the underlying document scope or intent. It also updates `.gitignore` so the local rehydration working files stay untracked.

The practical user effect is that the docs render more consistently and are easier to scan in editors, GitHub, and future review passes. The most visible cleanup is in the architecture docs and panic-recovery/operator runbooks, where list structure and Markdown block formatting are now mechanically consistent.

## Cause
The docs directory had drifted into a mixed state:

- some files were already valid Markdown but inconsistently formatted
- some files used non-Markdown separators, inline command blocks, or typography that looked fine in plain text but did not read as proper Markdown
- local rehydration working docs were being created in `docs/` and needed to stay local-only for now

That combination made the folder inconsistent and made it harder to trust that a `.md` file would actually render cleanly as Markdown.

## Root Cause
There was no single Markdown formatting pass applied across the current docs set, and a few newer or less-maintained documents had effectively become plain text with a `.md` extension. In parallel, local rehydration artifacts were being authored in `docs/` without an ignore rule to keep them out of normal repo changes.

## Fix
This PR makes a formatting-only pass over the affected tracked docs and keeps the content and scope intact. Specifically, it:

- normalizes Markdown list formatting in the architecture docs and related runbooks
- reformats the panic-recovery document into real Markdown structure while preserving its checklist content
- preserves the existing document substance instead of rewriting or expanding it
- updates `.gitignore` so the local rehydration working docs remain untracked

The ignored local-only docs are:

- `docs/rehydration-repo-snapshot.md`
- `docs/rehydration-template.md`
- `docs/session-delta.md`

## Validation
Checks used for this change:

- `git diff --check`
- heuristic pass for obvious non-Markdown patterns in `docs/*.md`
- spot review of the formatted output for the affected files

This is a docs-only cleanup. I did not run application tests or builds because no runtime code changed.
