### PR TITLE
[codex] Add architecture contract guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,205 @@
+# STATELOCK — CODEX CONTEXT FILE
+
+You are Codex operating inside the StateLock repository.
+
+Your role is:
+
+Implementation agent and repository operator.
+
+You have filesystem and git access to the repository and should rely on the repository contents as the source of truth.
+
+## PROJECT PURPOSE
+
+StateLock is a local-first continuity and memory system for LLM-based applications.
+
+Its purpose is to provide:
+
+- durable memory
+- cross-session continuity
+- provenance tracking
+- stable context construction
+- workflow stability for agents
+
+StateLock is designed to work with replaceable models (via LiteLLM or Ollama).
+
+The continuity layer is the stable component.
+
+## HIGH-LEVEL ARCHITECTURE
+
+StateLock follows a two-track architecture.
+
+### Core Track
+
+Stable runtime.
+
+Responsibilities:
+
+- durable semantic memory
+- Chroma-backed vector storage
+- memory query/save endpoints
+- session snapshot/restore
+- memory sidecar API
+
+Core must remain narrow and stable.
+
+Core should NOT become:
+
+- transcript ingestion system
+- promotion engine
+- graph database
+- model router
+
+### Observability Track
+
+Experimental cognition layer.
+
+Located under:
+
+`experimental/observability/`
+
+Responsibilities:
+
+- conversation capture
+- spans / turns
+- provenance
+- working context construction
+- telemetry
+- memory distillation
+- promotion decisions
+- episodic and procedural memory
+- relationship graph
+
+Observability may evolve rapidly.
+
+## KEY ARCHITECTURE RULE
+
+Observability -> Core projection must remain narrow.
+
+Observability generates rich artifacts.
+
+Core receives only reduced semantic projections.
+
+The boundary object is:
+
+`ProjectionRecord`
+
+## LOCAL DEVELOPMENT STACK
+
+The project currently runs three services.
+
+### Core API
+
+FastAPI  
+`http://127.0.0.1:8000`
+
+### Observability service
+
+`http://127.0.0.1:8001`
+
+### Next.js UI
+
+`http://127.0.0.1:3001`
+
+## DEV LIFECYCLE
+
+Primary commands:
+
+- `make dev-up`
+- `make dev-down`
+- `make dev-status`
+- `make dev-open`
+- `make dev-restart`
+
+`make dev-up` is idempotent and performs state reconciliation.
+
+Launcher logic lives under:
+
+`scripts/`
+
+## UI STRUCTURE
+
+Next.js product UI:
+
+`apps/web`
+
+Main routes:
+
+- `/`
+  Overview
+- `/operator`
+  Operator launchpad
+
+Additional product routes include:
+
+- Conversations
+- Highlights
+- Memory
+- Relationships
+- Runs
+- Learning Mode
+
+## IMPORTANT REPOSITORY DIRECTORIES
+
+- `app/`
+  Core runtime
+- `experimental/observability/`
+  Experimental cognition system
+- `apps/web/`
+  Next.js UI
+- `scripts/`
+  dev launcher scripts
+- `docs/`
+  architecture and design documentation
+
+## WHEN WORKING IN THIS REPOSITORY
+
+Follow these rules:
+
+1. Prefer minimal, surgical changes.
+2. Do not collapse the Core vs Observability architecture boundary.
+3. Avoid introducing large refactors without explanation.
+4. Verify claims by inspecting repository files.
+5. Prefer existing project patterns and conventions.
+
+If uncertain about architecture direction, ask before implementing.
+
+## TYPICAL CODEX TASKS
+
+You may be asked to:
+
+- inspect repository structure
+- implement features
+- fix bugs
+- generate documentation
+- propose pull requests
+- review architecture consistency
+
+Always cite relevant files when explaining findings.
+
+## OUTPUT EXPECTATIONS
+
+When reporting findings:
+
+- reference file paths
+- reference functions or sections
+- prefer evidence over assumptions
+
+## REHYDRATION FILES
+
+For project context also consult:
+
+- `docs/rehydration-repo-snapshot.md`
+- `docs/session-delta.md`
+- `docs/rehydration-template.md`
+
+## Architecture Governance Files
+
+Important architecture references:
+
+- `docs/architecture-contract.yaml`
+- `docs/architecture-contract-audit.md`
+- `docs/rehydration-template.md`
+- `docs/rehydration-repo-snapshot.md`
+- `docs/session-delta.md`
+
+When making architectural changes, consult these files first.

--- a/docs/architecture-contract-audit.md
+++ b/docs/architecture-contract-audit.md
@@ -1,0 +1,201 @@
+# Architecture Contract Audit
+
+## Scope
+
+This audit checks the current repository against [`architecture-contract.yaml`](./architecture-contract.yaml).
+
+It is intentionally lightweight:
+
+- code and current repo layout are treated as implementation truth
+- architecture docs are treated as direction unless verified in runtime code
+
+## Overall Assessment
+
+The repo appears **mostly consistent** with the contract.
+
+The current implementation still matches the intended two-track split:
+
+- Core remains narrow and memory-oriented under [`app/`](../app/)
+- Observability remains the richer continuity subsystem under [`experimental/observability/`](../experimental/observability/)
+- the web UI preserves the track boundary instead of collapsing the two systems into one backend
+
+## Evidence For Consistency
+
+### Core remains narrow
+
+Core routing and schemas are still centered on memory blocks and insights:
+
+- [`app/routers/memories.py`](../app/routers/memories.py)
+- [`app/routers/insights.py`](../app/routers/insights.py)
+- [`app/models/schemas.py`](../app/models/schemas.py)
+- [`app/services/memory_service.py`](../app/services/memory_service.py)
+
+What is present:
+
+- memory CRUD and upsert
+- semantic and hybrid query
+- session snapshot and restore
+- stats, sessions, and tags
+- health and readiness
+
+What is notably absent from Core:
+
+- transcript ingestion models
+- conversation or turn models
+- promotion pipeline objects
+- graph ownership
+- model-routing logic
+
+That matches the contract.
+
+### Observability owns rich continuity behavior
+
+Observability is still the subsystem that carries conversation-level mechanics:
+
+- [`experimental/observability/app/main.py`](../experimental/observability/app/main.py)
+- [`experimental/observability/app/db/models.py`](../experimental/observability/app/db/models.py)
+- [`experimental/observability/app/api/conversations.py`](../experimental/observability/app/api/conversations.py)
+- [`experimental/observability/app/api/turns.py`](../experimental/observability/app/api/turns.py)
+- [`experimental/observability/app/api/context.py`](../experimental/observability/app/api/context.py)
+- [`experimental/observability/app/api/telemetry.py`](../experimental/observability/app/api/telemetry.py)
+- [`experimental/observability/app/api/governance.py`](../experimental/observability/app/api/governance.py)
+- [`experimental/observability/app/api/memory.py`](../experimental/observability/app/api/memory.py)
+- [`experimental/observability/app/context_builder/builder.py`](../experimental/observability/app/context_builder/builder.py)
+- [`experimental/observability/app/memory/distill.py`](../experimental/observability/app/memory/distill.py)
+
+This matches the contract’s expectation that Observability owns:
+
+- conversations and turns
+- highlights/spans
+- working context
+- telemetry and explainability
+- governance
+- learned memory and distillation
+- provenance and contradiction signals
+
+### The UI preserves the backend split
+
+The Next app remains a thin front-end layer over separate Core and Observability upstreams:
+
+- [`apps/web/lib/proxy.ts`](../apps/web/lib/proxy.ts)
+- [`apps/web/app/layout.tsx`](../apps/web/app/layout.tsx)
+
+The proxy still distinguishes:
+
+- `STATELOCK_CORE_BASE_URL`
+- `STATELOCK_OBS_BASE_URL`
+
+That is consistent with the contract rule that the UI should preserve track visibility rather than hide architectural boundaries.
+
+### Launcher and local stack align with current contract
+
+The local stack contract is consistent with the current launcher implementation:
+
+- [`Makefile`](../Makefile)
+- [`scripts/dev-up.sh`](../scripts/dev-up.sh)
+- [`scripts/dev-down.sh`](../scripts/dev-down.sh)
+- [`scripts/dev-status.sh`](../scripts/dev-status.sh)
+- [`scripts/dev-restart.sh`](../scripts/dev-restart.sh)
+- [`scripts/dev-open.sh`](../scripts/dev-open.sh)
+- [`scripts/lib/dev-common.sh`](../scripts/lib/dev-common.sh)
+- [`README.md`](../README.md)
+
+Current defaults match the contract:
+
+- Core on `127.0.0.1:8000`
+- Observability on `127.0.0.1:8001`
+- UI on `127.0.0.1:3001`
+
+## Likely Violations, Ambiguities, Or Drift Risks
+
+### No runtime `ProjectionRecord` exists yet
+
+This is the main gap.
+
+`ProjectionRecord` is described in architecture docs as the intended cross-track boundary object:
+
+- [`docs/architecture-promotion-schemas.md`](./architecture-promotion-schemas.md)
+- [`docs/architecture-memory-graph.md`](./architecture-memory-graph.md)
+
+But it does **not** currently exist in runtime code under [`app/`](../app/) or [`experimental/observability/`](../experimental/observability/).
+
+Practical implication:
+
+- the architecture direction is clear
+- the boundary object is still a design contract, not an implemented schema
+
+This is not a violation of the contract as written, because the contract marks it as intended and not yet implemented. It is still the biggest drift risk if future work starts projecting richer objects into Core without first formalizing the boundary.
+
+### Promotion, graph, and policy-profile docs are ahead of implementation
+
+Several architecture docs describe strong future directions:
+
+- [`docs/architecture-promotion-engine.md`](./architecture-promotion-engine.md)
+- [`docs/architecture-promotion-schemas.md`](./architecture-promotion-schemas.md)
+- [`docs/architecture-memory-graph.md`](./architecture-memory-graph.md)
+- [`docs/architecture-memory-policy-profiles.md`](./architecture-memory-policy-profiles.md)
+
+The runtime code currently supports adjacent building blocks, especially in Observability, but not the full schema or lifecycle described in those docs.
+
+Risk:
+
+- future contributors may treat those docs as already implemented unless the repo keeps marking these concepts as future-oriented
+
+### Observability remains both important and still explicitly experimental
+
+The product UI depends on Observability routes and data, but the subsystem still lives under:
+
+- [`experimental/observability/`](../experimental/observability/)
+
+This is repo-consistent, but it is still an ambiguity worth noting:
+
+- operationally important
+- architecturally isolated
+- not yet promoted into the main app namespace
+
+That is acceptable now, but it is an architecture-sensitive area.
+
+### Local stack port language can still be read two ways
+
+The repo-root launcher uses Observability on `8001`, but standalone Observability docs still discuss `8000` for isolated startup:
+
+- [`README.md`](../README.md)
+- [`experimental/observability/README.md`](../experimental/observability/README.md)
+- [`experimental/observability/docs/FIRST_30_MINUTES.md`](../experimental/observability/docs/FIRST_30_MINUTES.md)
+- [`experimental/observability/docs/REPO_GUIDE.md`](../experimental/observability/docs/REPO_GUIDE.md)
+
+This is not a contract violation, but it is a documentation drift risk if the context is not stated clearly.
+
+## Most Architecture-Sensitive Files And Directories
+
+Highest sensitivity:
+
+- [`app/`](../app/)
+- [`main.py`](../main.py)
+- [`experimental/observability/`](../experimental/observability/)
+- [`apps/web/lib/proxy.ts`](../apps/web/lib/proxy.ts)
+- [`apps/web/lib/product/`](../apps/web/lib/product/)
+- [`scripts/lib/dev-common.sh`](../scripts/lib/dev-common.sh)
+- [`docs/architecture-tracks.md`](./architecture-tracks.md)
+- [`docs/architecture-continuity-layer.md`](./architecture-continuity-layer.md)
+- [`docs/architecture-promotion-schemas.md`](./architecture-promotion-schemas.md)
+
+Why these matter:
+
+- `app/` is where Core could accidentally absorb forbidden concerns
+- `experimental/observability/` is where rich continuity logic should continue to land first
+- `apps/web/lib/proxy.ts` is the concrete track boundary in the product UI
+- `apps/web/lib/product/` is where the UI can accidentally overstate backend capabilities
+- `scripts/lib/dev-common.sh` shapes the real local lifecycle contract developers experience
+- the architecture docs above are the primary written boundary definitions contributors will read
+
+## Bottom Line
+
+The repo currently appears **compatible with the contract**.
+
+The main caution is not a current violation inside Core. It is future drift:
+
+- if promotion logic moves into Core
+- if graph ownership moves into Core
+- if UI copy starts implying implemented projection/graph/profile systems that do not exist
+- if `ProjectionRecord` is skipped and rich Observability state starts leaking directly into Core

--- a/docs/architecture-contract.yaml
+++ b/docs/architecture-contract.yaml
@@ -1,0 +1,112 @@
+version: 1
+contract_name: statelock-architecture-contract
+status: draft
+
+architecture:
+  model: two-track
+  repo_truth_rule:
+    - Runtime code and current repo layout are the source of truth for implemented behavior.
+    - Architecture docs may describe intended direction and should not be treated as proof of implementation.
+
+tracks:
+  core:
+    purpose: stable durable-memory sidecar runtime
+    primary_paths:
+      - main.py
+      - app/
+    owns:
+      - memory block storage and retrieval
+      - /memories APIs
+      - /stats, /sessions, and /tags insights APIs
+      - health and readiness endpoints
+      - snapshot and restore flows for session-scoped memory
+      - chroma-backed persistence
+    forbidden_concerns:
+      - transcript ingestion
+      - conversation and turn storage
+      - working-context construction
+      - promotion engine ownership
+      - graph database ownership
+      - model routing
+      - rich governance and telemetry logic
+
+  observability:
+    purpose: richer continuity, traceability, and learning subsystem
+    primary_paths:
+      - experimental/observability/
+    owns:
+      - conversations, turns, and spans
+      - working-context construction
+      - telemetry snapshots and explainability
+      - governance actions and auditability
+      - conversation import and export
+      - memory distillation and learned memory records
+      - provenance, contradiction, and quarantine signals
+    expected_concerns:
+      - promotion-oriented artifacts and evidence
+      - relationship and graph-like modeling before any Core projection
+      - policy and learning controls before any Core-side narrowing
+
+projection_boundary:
+  direction: observability_to_core
+  rule: only reduced semantic memory should cross into Core
+  boundary_object:
+    name: ProjectionRecord
+    owner_track: observability
+    status: intended_boundary_object_not_yet_implemented_in_runtime
+    purpose:
+      - link an Observability-owned promotion decision or learned record to the Core memory block that was created or updated
+      - preserve projection provenance without making Core own rich continuity state
+  core_projection_shape:
+    compatible_with:
+      - app/models/schemas.py:MemoryUpsert
+      - app/models/schemas.py:MemoryCreate
+  disallowed_crossings:
+    - raw conversation transcripts into Core as a primary storage model
+    - rich promotion artifacts stored as first-class Core records
+    - graph edges owned by Core
+    - model-router or gateway responsibilities attached to Core
+
+local_stack:
+  ports:
+    core: 8000
+    observability: 8001
+    web: 3001
+  urls:
+    core: http://127.0.0.1:8000
+    observability: http://127.0.0.1:8001
+    web: http://127.0.0.1:3001
+
+lifecycle:
+  recommended_commands:
+    up: make dev-up
+    down: make dev-down
+    status: make dev-status
+    restart: make dev-restart
+    logs: make dev-logs
+    open: make dev-open
+  behavior_contract:
+    - dev-up should be idempotent and ensure the local stack is running.
+    - dev-status should report overall stack state and per-service health with URLs.
+    - stale pid files should be repaired safely by the launcher.
+    - port conflicts should be reported clearly instead of being treated as generic startup failures.
+
+repo_rules:
+  - path: app/
+    sensitivity: high
+    rule: keep Core narrow and memory-oriented; do not add conversation, routing, graph, or promotion-engine ownership here without explicit architecture change.
+  - path: experimental/observability/
+    sensitivity: high
+    rule: place richer continuity, telemetry, governance, distillation, and relationship logic here first.
+  - path: apps/web/
+    sensitivity: high
+    rule: preserve track visibility in the UI and avoid implying backend capabilities that do not exist.
+  - path: apps/web/lib/proxy.ts
+    sensitivity: high
+    rule: maintain explicit Core vs Observability upstream separation.
+  - path: scripts/
+    sensitivity: medium
+    rule: launcher behavior should stay humane and idempotent without redefining architecture boundaries.
+  - path: docs/architecture-*.md
+    sensitivity: medium
+    rule: keep direction aligned with code reality and mark future concepts clearly when not implemented.


### PR DESCRIPTION
## Summary

This PR adds a lightweight, machine-readable architecture contract for StateLock and a short repo audit grounded in the current codebase.

The goal is to create a small architectural guardrail without introducing a policy engine, CI enforcement, or new runtime machinery.

## What changed

- added `docs/architecture-contract.yaml`
- added `docs/architecture-contract-audit.md`
- normalized the root `AGENTS.md` into proper Markdown without changing its substance

## Why

The repo already has strong architecture direction across `README.md` and the architecture docs, but the highest-signal boundaries were still distributed across prose documents.

That makes drift easier in a few places:

- Core could gradually absorb conversation or promotion concerns
- Observability future-shape docs could be mistaken for implemented runtime behavior
- the UI or launcher could blur the Core vs Observability split
- projection into Core could happen without a narrow, explicit boundary contract

This PR makes those boundaries easier to read and reuse in a single, human-editable file.

## Contract scope

The new YAML contract captures:

- the two-track architecture model
- Core purpose and explicitly forbidden concerns
- Observability purpose and expected concerns
- the Observability -> Core projection boundary
- `ProjectionRecord` as the intended boundary object
- current local stack ports and URLs
- current lifecycle commands
- a small set of path-based repo rules for architecture-sensitive areas

## Audit findings

The audit concludes that the repo is mostly consistent with the contract today.

The main finding is that `ProjectionRecord` is documented as the intended cross-track boundary object, but it does not yet exist in runtime code. That is treated explicitly as a future-facing contract element rather than an implemented schema.

Other noted drift risks are:

- promotion / graph / policy-profile docs are ahead of runtime implementation
- Observability is operationally important while still explicitly isolated under `experimental/observability/`
- standalone versus launcher port language can still be misread if docs are read without context

## User impact

This is documentation-only. It does not change runtime behavior.

The practical effect is that future architecture-sensitive work now has a smaller, clearer contract to check before making changes in `app/`, `experimental/observability/`, `apps/web/`, or the launcher.

## Validation

- reviewed current Core routes, schemas, launcher scripts, UI proxy boundaries, and Observability models against the new contract
- confirmed the contract matches the current launcher ports and lifecycle commands
- confirmed the audit reflects current repo reality rather than aspirational docs
- no code or runtime behavior changed
