### PR TITLE
[codex] Trim AGENTS rehydration refs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,6 @@ When reporting findings:
 For project context also consult:
 
 - `docs/rehydration-repo-snapshot.md`
-- `docs/session-delta.md`
 - `docs/rehydration-template.md`
 
 ## Architecture Governance Files


### PR DESCRIPTION
## Summary

This PR makes a very small cleanup in `AGENTS.md` by removing `docs/session-delta.md` from the "For project context also consult" list.

## Why

That list is intended to point Codex to the most relevant always-useful rehydration files. `session-delta.md` is more situational than the repo snapshot and rehydration template, so removing it keeps the guidance tighter without changing any repository behavior.

## Scope

- one-line docs-only change in `AGENTS.md`
- no runtime changes
- no architecture or workflow changes

## Validation

- reviewed the diff to confirm the change is limited to a single path removal
